### PR TITLE
Fix creation of external services

### DIFF
--- a/charts/redis-cluster/templates/follower-service.yaml
+++ b/charts/redis-cluster/templates/follower-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.externalService.enabled -}}
 {{- if (gt (int .Values.redisCluster.follower.replicas) 0) }}
 ---
 apiVersion: v1
@@ -26,4 +27,5 @@ spec:
       port: {{ .Values.externalService.port }}
       targetPort: 6379
       name: client
+{{- end }}
 {{- end }}

--- a/charts/redis-cluster/templates/leader-service.yaml
+++ b/charts/redis-cluster/templates/leader-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.externalService.enabled -}}
 {{- if (gt (int .Values.redisCluster.leader.replicas) 0) }}
 ---
 apiVersion: v1
@@ -26,4 +27,5 @@ spec:
       port: {{ .Values.externalService.port }}
       targetPort: 6379
       name: client
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Don't create Service <name>-leader-external-service and <name>-follower-external-service when externalService.enabled=false