### PR TITLE
Replace CRDs with results of kustomize for crd from operator repo

### DIFF
--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: redis-operator
 sources:
   - https://github.com/OT-CONTAINER-KIT/redis-operator
-version: 0.10.0
+version: 0.10.1
 home: https://github.com/OT-CONTAINER-KIT/redis-operator
 icon: https://github.com/OT-CONTAINER-KIT/redis-operator/raw/master/static/redis-operator-logo.svg
 keywords:

--- a/charts/redis-operator/crds/redis-cluster.yaml
+++ b/charts/redis-operator/crds/redis-cluster.yaml
@@ -15,57 +15,57 @@ spec:
     singular: rediscluster
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: Current cluster node count
-          jsonPath: .spec.clusterSize
-          name: ClusterSize
-          type: integer
-        - description: Overridden Leader replica count
-          jsonPath: .spec.redisLeader.replicas
-          name: LeaderReplicas
-          type: integer
-        - description: Overridden Follower replica count
-          jsonPath: .spec.redisFollower.replicas
-          name: FollowerReplicas
-          type: integer
-        - description: Age of Cluster
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: RedisCluster is the Schema for the redisclusters API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - additionalPrinterColumns:
+    - description: Current cluster node count
+      jsonPath: .spec.clusterSize
+      name: ClusterSize
+      type: integer
+    - description: Overridden Leader replica count
+      jsonPath: .spec.redisLeader.replicas
+      name: LeaderReplicas
+      type: integer
+    - description: Overridden Follower replica count
+      jsonPath: .spec.redisFollower.replicas
+      name: FollowerReplicas
+      type: integer
+    - description: Age of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RedisCluster is the Schema for the redisclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: RedisClusterSpec defines the desired state of RedisCluster
-              properties:
-                TLS:
-                  description: TLS Configuration for redis instances
-                  properties:
-                    ca:
-                      type: string
-                    cert:
-                      type: string
-                    key:
-                      type: string
-                    secret:
-                      description: Reference to secret which contains the certificates
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits used to set permissions
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RedisClusterSpec defines the desired state of RedisCluster
+            properties:
+              TLS:
+                description: TLS Configuration for redis instances
+                properties:
+                  ca:
+                    type: string
+                  cert:
+                    type: string
+                  key:
+                    type: string
+                  secret:
+                    description: Reference to secret which contains the certificates
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits used to set permissions
                           on created files by default. Must be an octal value between
                           0000 and 0777 or a decimal value between 0 and 511. YAML
                           accepts both octal and decimal values, JSON requires decimal
@@ -73,26 +73,26 @@ spec:
                           the path are not affected by this setting. This might be
                           in conflict with other options that affect the file mode,
                           like fsGroup, and the result can be other mode bits set.'
-                          format: int32
-                          type: integer
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
                         items:
-                          description: If unspecified, each key-value pair in the Data
-                            field of the referenced Secret will be projected into the
-                            volume as a file whose name is the key and content is the
-                            value. If specified, the listed keys will be projected into
-                            the specified paths, and unlisted keys will not be present.
-                            If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional.
-                            Paths must be relative and may not contain the '..' path
-                            or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits used to set permissions
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits used to set permissions
                                 on this file. Must be an octal value between 0000
                                 and 0777 or a decimal value between 0 and 511. YAML
                                 accepts both octal and decimal values, JSON requires
@@ -101,118 +101,118 @@ spec:
                                 conflict with other options that affect the file mode,
                                 like fsGroup, and the result can be other mode bits
                                 set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map the
-                                  key to. May not be an absolute path. May not contain
-                                  the path element '..'. May not start with the string
-                                  '..'.
-                                type: string
-                            required:
-                              - key
-                              - path
-                            type: object
-                          type: array
-                        optional:
-                          description: Specify whether the Secret or its keys must be
-                            defined
-                          type: boolean
-                        secretName:
-                          description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                          type: string
-                      type: object
-                  required:
-                    - secret
-                  type: object
-                clusterSize:
-                  format: int32
-                  minimum: 3
-                  type: integer
-                kubernetesConfig:
-                  description: KubernetesConfig will be the JSON struct for Basic Redis
-                    Config
-                  properties:
-                    image:
-                      type: string
-                    imagePullPolicy:
-                      description: PullPolicy describes a policy for if/when to pull
-                        a container image
-                      type: string
-                    imagePullSecrets:
-                      items:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                        type: object
-                      type: array
-                    redisSecret:
-                      description: ExistingPasswordSecret is the struct to access the
-                        existing secret
-                      properties:
-                        key:
-                          type: string
-                        name:
-                          type: string
-                      type: object
-                    resources:
-                      description: ResourceRequirements describes the compute resource
-                        requirements.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                          required:
+                          - key
+                          - path
                           type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                required:
+                - secret
+                type: object
+              clusterSize:
+                format: int32
+                minimum: 3
+                type: integer
+              kubernetesConfig:
+                description: KubernetesConfig will be the JSON struct for Basic Redis
+                  Config
+                properties:
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    type: array
+                  redisSecret:
+                    description: ExistingPasswordSecret is the struct to access the
+                      existing secret
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                          type: object
-                      type: object
-                  required:
-                    - image
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  type: object
-                priorityClassName:
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              nodeSelector:
+                additionalProperties:
                   type: string
-                redisExporter:
-                  description: RedisExporter interface will have the information for
-                    redis exporter related stuff
-                  properties:
-                    enabled:
-                      type: boolean
-                    env:
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
+                type: object
+              priorityClassName:
+                type: string
+              redisExporter:
+                description: RedisExporter interface will have the information for
+                  redis exporter related stuff
+                properties:
+                  enabled:
+                    type: boolean
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
                             the container and any service environment variables. If
                             a variable cannot be resolved, the reference in the input
@@ -221,6 +221,2734 @@ spec:
                             "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                             Escaped references will never be expanded, regardless
                             of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              redisFollower:
+                description: RedisFollower interface will have the redis follower
+                  configuration
+                properties:
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is beta-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is beta-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                          This is an alpha field and requires enabling GRPCContainerProbe
+                          feature gate.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: "Service is the name of the service to place
+                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              \n If this is not specified, the default behavior is
+                              defined by gRPC."
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully upon probe failure. The grace period
+                          is the duration in seconds after the processes running in
+                          the pod are sent a termination signal and the time when
+                          the processes are forcibly halted with a kill signal. Set
+                          this value longer than the expected cleanup time for your
+                          process. If this value is nil, the pod's terminationGracePeriodSeconds
+                          will be used. Otherwise, this value overrides the value
+                          provided by the pod spec. Value must be non-negative integer.
+                          The value zero indicates stop immediately via the kill signal
+                          (no opportunity to shut down). This is a beta field and
+                          requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is
+                          used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  pdb:
+                    description: RedisPodDisruptionBudget configure a PodDisruptionBudget
+                      on the resource (leader/follower)
+                    properties:
+                      enabled:
+                        type: boolean
+                      maxUnavailable:
+                        format: int32
+                        type: integer
+                      minAvailable:
+                        format: int32
+                        type: integer
+                    type: object
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                          This is an alpha field and requires enabling GRPCContainerProbe
+                          feature gate.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: "Service is the name of the service to place
+                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              \n If this is not specified, the default behavior is
+                              defined by gRPC."
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully upon probe failure. The grace period
+                          is the duration in seconds after the processes running in
+                          the pod are sent a termination signal and the time when
+                          the processes are forcibly halted with a kill signal. Set
+                          this value longer than the expected cleanup time for your
+                          process. If this value is nil, the pod's terminationGracePeriodSeconds
+                          will be used. Otherwise, this value overrides the value
+                          provided by the pod spec. Value must be non-negative integer.
+                          The value zero indicates stop immediately via the kill signal
+                          (no opportunity to shut down). This is a beta field and
+                          requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is
+                          used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  redisConfig:
+                    description: RedisConfig defines the external configuration of
+                      Redis
+                    properties:
+                      additionalRedisConfig:
+                        type: string
+                    type: object
+                  replicas:
+                    format: int32
+                    type: integer
+                type: object
+              redisLeader:
+                description: RedisLeader interface will have the redis leader configuration
+                properties:
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is beta-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces. This
+                                        field is beta-level and is only honored when
+                                        PodAffinityNamespaceSelector feature is enabled.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  livenessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                          This is an alpha field and requires enabling GRPCContainerProbe
+                          feature gate.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: "Service is the name of the service to place
+                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              \n If this is not specified, the default behavior is
+                              defined by gRPC."
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully upon probe failure. The grace period
+                          is the duration in seconds after the processes running in
+                          the pod are sent a termination signal and the time when
+                          the processes are forcibly halted with a kill signal. Set
+                          this value longer than the expected cleanup time for your
+                          process. If this value is nil, the pod's terminationGracePeriodSeconds
+                          will be used. Otherwise, this value overrides the value
+                          provided by the pod spec. Value must be non-negative integer.
+                          The value zero indicates stop immediately via the kill signal
+                          (no opportunity to shut down). This is a beta field and
+                          requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is
+                          used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  pdb:
+                    description: RedisPodDisruptionBudget configure a PodDisruptionBudget
+                      on the resource (leader/follower)
+                    properties:
+                      enabled:
+                        type: boolean
+                      maxUnavailable:
+                        format: int32
+                        type: integer
+                      minAvailable:
+                        format: int32
+                        type: integer
+                    type: object
+                  readinessProbe:
+                    description: Probe describes a health check to be performed against
+                      a container to determine whether it is alive or ready to receive
+                      traffic.
+                    properties:
+                      exec:
+                        description: Exec specifies the action to take.
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      grpc:
+                        description: GRPC specifies an action involving a GRPC port.
+                          This is an alpha field and requires enabling GRPCContainerProbe
+                          feature gate.
+                        properties:
+                          port:
+                            description: Port number of the gRPC service. Number must
+                              be in the range 1 to 65535.
+                            format: int32
+                            type: integer
+                          service:
+                            description: "Service is the name of the service to place
+                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                              \n If this is not specified, the default behavior is
+                              defined by gRPC."
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        format: int32
+                        type: integer
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness and startup. Minimum value is
+                          1.
+                        format: int32
+                        type: integer
+                      tcpSocket:
+                        description: TCPSocket specifies an action involving a TCP
+                          port.
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - port
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: Optional duration in seconds the pod needs to
+                          terminate gracefully upon probe failure. The grace period
+                          is the duration in seconds after the processes running in
+                          the pod are sent a termination signal and the time when
+                          the processes are forcibly halted with a kill signal. Set
+                          this value longer than the expected cleanup time for your
+                          process. If this value is nil, the pod's terminationGracePeriodSeconds
+                          will be used. Otherwise, this value overrides the value
+                          provided by the pod spec. Value must be non-negative integer.
+                          The value zero indicates stop immediately via the kill signal
+                          (no opportunity to shut down). This is a beta field and
+                          requires enabling ProbeTerminationGracePeriod feature gate.
+                          Minimum value is 1. spec.terminationGracePeriodSeconds is
+                          used if unset.
+                        format: int64
+                        type: integer
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        format: int32
+                        type: integer
+                    type: object
+                  redisConfig:
+                    description: RedisConfig defines the external configuration of
+                      Redis
+                    properties:
+                      additionalRedisConfig:
+                        type: string
+                    type: object
+                  replicas:
+                    format: int32
+                    minimum: 3
+                    type: integer
+                type: object
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              securityContext:
+                description: PodSecurityContext holds pod-level security attributes
+                  and common container settings. Some fields are also present in container.securityContext.  Field
+                  values of container.securityContext take precedence over field values
+                  of PodSecurityContext.
+                properties:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume. Note that this field cannot be set when spec.os.name
+                      is windows."
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used. Note that this field cannot
+                      be set when spec.os.name is windows.'
+                    type: string
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container. Note that this field cannot
+                      be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by the containers in this
+                      pod. Note that this field cannot be set when spec.os.name is
+                      windows.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container. Note
+                      that this field cannot be set when spec.os.name is windows.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch. Note that this field cannot be set when
+                      spec.os.name is windows.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence. Note
+                      that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container. This field is alpha-level
+                          and will only be honored by components that enable the WindowsHostProcessContainers
+                          feature flag. Setting this field without the feature flag
+                          will result in errors when validating the Pod. All of a
+                          Pod's containers must have the same effective HostProcess
+                          value (it is not allowed to have a mix of HostProcess containers
+                          and non-HostProcess containers).  In addition, if HostProcess
+                          is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
+              sidecars:
+                items:
+                  description: Sidecar for each Redis pods
+                  properties:
+                    env:
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
                             type: string
                           valueFrom:
                             description: Source for the environment variable's value.
@@ -233,23 +2961,24 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
                                 properties:
                                   apiVersion:
                                     description: Version of the schema the FieldPath
@@ -260,22 +2989,23 @@ spec:
                                       specified API version.
                                     type: string
                                 required:
-                                  - fieldPath
+                                - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
                                 properties:
                                   containerName:
                                     description: 'Container name: required for volumes,
-                                    optional for env vars'
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
-                                      - type: integer
-                                      - type: string
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -284,7 +3014,7 @@ spec:
                                     description: 'Required: resource to select'
                                     type: string
                                 required:
-                                  - resource
+                                - resource
                                 type: object
                               secretKeyRef:
                                 description: Selects a key of a secret in the pod's
@@ -295,20 +3025,21 @@ spec:
                                       be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                             type: object
                         required:
-                          - name
+                        - name
                         type: object
                       type: array
                     image:
@@ -317,6 +3048,8 @@ spec:
                       description: PullPolicy describes a policy for if/when to pull
                         a container image
                       type: string
+                    name:
+                      type: string
                     resources:
                       description: ResourceRequirements describes the compute resource
                         requirements.
@@ -324,2826 +3057,93 @@ spec:
                         limits:
                           additionalProperties:
                             anyOf:
-                              - type: integer
-                              - type: string
+                            - type: integer
+                            - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
                             anyOf:
-                              - type: integer
-                              - type: string
+                            - type: integer
+                            - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
                   required:
-                    - image
+                  - image
+                  - name
                   type: object
-                redisFollower:
-                  description: RedisFollower interface will have the redis follower
-                    configuration
-                  properties:
-                    affinity:
-                      description: Affinity is a group of affinity scheduling rules.
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of namespaces
-                                          that the term applies to. The term is applied
-                                          to the union of the namespaces selected by
-                                          this field and the ones listed in the namespaces
-                                          field. null selector and null or empty namespaces
-                                          list means "this pod's namespace". An empty
-                                          selector ({}) matches all namespaces. This
-                                          field is beta-level and is only honored when
-                                          PodAffinityNamespaceSelector feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static list
-                                          of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces
-                                          listed in this field and the ones selected
-                                          by namespaceSelector. null or empty namespaces
-                                          list and null namespaceSelector means "this
-                                          pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of namespaces
-                                          that the term applies to. The term is applied
-                                          to the union of the namespaces selected by
-                                          this field and the ones listed in the namespaces
-                                          field. null selector and null or empty namespaces
-                                          list means "this pod's namespace". An empty
-                                          selector ({}) matches all namespaces. This
-                                          field is beta-level and is only honored when
-                                          PodAffinityNamespaceSelector feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static list
-                                          of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces
-                                          listed in this field and the ones selected
-                                          by namespaceSelector. null or empty namespaces
-                                          list and null namespaceSelector means "this
-                                          pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    livenessProbe:
-                      description: Probe describes a health check to be performed against
-                        a container to determine whether it is alive or ready to receive
-                        traffic.
-                      properties:
-                        exec:
-                          description: Exec specifies the action to take.
-                          properties:
-                            command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          description: Minimum consecutive failures for the probe to
-                            be considered failed after having succeeded. Defaults to
-                            3. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        grpc:
-                          description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
-                            feature gate.
-                          properties:
-                            port:
-                              description: Port number of the gRPC service. Number must
-                                be in the range 1 to 65535.
-                              format: int32
-                              type: integer
-                            service:
-                              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        httpGet:
-                          description: HTTPGet specifies the http request to perform.
-                          properties:
-                            host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
-                              type: string
-                            httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
-                              items:
-                                description: HTTPHeader describes a custom header to
-                                  be used in HTTP probes
-                                properties:
-                                  name:
-                                    description: The header field name
-                                    type: string
-                                  value:
-                                    description: The header field value
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              description: Path to access on the HTTP server.
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                            scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          description: Minimum consecutive successes for the probe to
-                            be considered successful after having failed. Defaults to
-                            1. Must be 1 for liveness and startup. Minimum value is
-                            1.
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
-                          properties:
-                            host:
-                              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs to
-                            terminate gracefully upon probe failure. The grace period
-                            is the duration in seconds after the processes running in
-                            the pod are sent a termination signal and the time when
-                            the processes are forcibly halted with a kill signal. Set
-                            this value longer than the expected cleanup time for your
-                            process. If this value is nil, the pod's terminationGracePeriodSeconds
-                            will be used. Otherwise, this value overrides the value
-                            provided by the pod spec. Value must be non-negative integer.
-                            The value zero indicates stop immediately via the kill signal
-                            (no opportunity to shut down). This is a beta field and
-                            requires enabling ProbeTerminationGracePeriod feature gate.
-                            Minimum value is 1. spec.terminationGracePeriodSeconds is
-                            used if unset.
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                      type: object
-                    pdb:
-                      description: RedisPodDisruptionBudget configure a PodDisruptionBudget
-                        on the resource (leader/follower)
-                      properties:
-                        enabled:
-                          type: boolean
-                        maxUnavailable:
-                          format: int32
-                          type: integer
-                        minAvailable:
-                          format: int32
-                          type: integer
-                      type: object
-                    readinessProbe:
-                      description: Probe describes a health check to be performed against
-                        a container to determine whether it is alive or ready to receive
-                        traffic.
-                      properties:
-                        exec:
-                          description: Exec specifies the action to take.
-                          properties:
-                            command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          description: Minimum consecutive failures for the probe to
-                            be considered failed after having succeeded. Defaults to
-                            3. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        grpc:
-                          description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
-                            feature gate.
-                          properties:
-                            port:
-                              description: Port number of the gRPC service. Number must
-                                be in the range 1 to 65535.
-                              format: int32
-                              type: integer
-                            service:
-                              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        httpGet:
-                          description: HTTPGet specifies the http request to perform.
-                          properties:
-                            host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
-                              type: string
-                            httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
-                              items:
-                                description: HTTPHeader describes a custom header to
-                                  be used in HTTP probes
-                                properties:
-                                  name:
-                                    description: The header field name
-                                    type: string
-                                  value:
-                                    description: The header field value
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              description: Path to access on the HTTP server.
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                            scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          description: Minimum consecutive successes for the probe to
-                            be considered successful after having failed. Defaults to
-                            1. Must be 1 for liveness and startup. Minimum value is
-                            1.
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
-                          properties:
-                            host:
-                              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs to
-                            terminate gracefully upon probe failure. The grace period
-                            is the duration in seconds after the processes running in
-                            the pod are sent a termination signal and the time when
-                            the processes are forcibly halted with a kill signal. Set
-                            this value longer than the expected cleanup time for your
-                            process. If this value is nil, the pod's terminationGracePeriodSeconds
-                            will be used. Otherwise, this value overrides the value
-                            provided by the pod spec. Value must be non-negative integer.
-                            The value zero indicates stop immediately via the kill signal
-                            (no opportunity to shut down). This is a beta field and
-                            requires enabling ProbeTerminationGracePeriod feature gate.
-                            Minimum value is 1. spec.terminationGracePeriodSeconds is
-                            used if unset.
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                      type: object
-                    redisConfig:
-                      description: RedisConfig defines the external configuration of
-                        Redis
-                      properties:
-                        additionalRedisConfig:
-                          type: string
-                      type: object
-                    replicas:
-                      format: int32
-                      type: integer
-                  type: object
-                redisLeader:
-                  description: RedisLeader interface will have the redis leader configuration
-                  properties:
-                    affinity:
-                      description: Affinity is a group of affinity scheduling rules.
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of namespaces
-                                          that the term applies to. The term is applied
-                                          to the union of the namespaces selected by
-                                          this field and the ones listed in the namespaces
-                                          field. null selector and null or empty namespaces
-                                          list means "this pod's namespace". An empty
-                                          selector ({}) matches all namespaces. This
-                                          field is beta-level and is only honored when
-                                          PodAffinityNamespaceSelector feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static list
-                                          of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces
-                                          listed in this field and the ones selected
-                                          by namespaceSelector. null or empty namespaces
-                                          list and null namespaceSelector means "this
-                                          pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of namespaces
-                                          that the term applies to. The term is applied
-                                          to the union of the namespaces selected by
-                                          this field and the ones listed in the namespaces
-                                          field. null selector and null or empty namespaces
-                                          list means "this pod's namespace". An empty
-                                          selector ({}) matches all namespaces. This
-                                          field is beta-level and is only honored when
-                                          PodAffinityNamespaceSelector feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static list
-                                          of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces
-                                          listed in this field and the ones selected
-                                          by namespaceSelector. null or empty namespaces
-                                          list and null namespaceSelector means "this
-                                          pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    livenessProbe:
-                      description: Probe describes a health check to be performed against
-                        a container to determine whether it is alive or ready to receive
-                        traffic.
-                      properties:
-                        exec:
-                          description: Exec specifies the action to take.
-                          properties:
-                            command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          description: Minimum consecutive failures for the probe to
-                            be considered failed after having succeeded. Defaults to
-                            3. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        grpc:
-                          description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
-                            feature gate.
-                          properties:
-                            port:
-                              description: Port number of the gRPC service. Number must
-                                be in the range 1 to 65535.
-                              format: int32
-                              type: integer
-                            service:
-                              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        httpGet:
-                          description: HTTPGet specifies the http request to perform.
-                          properties:
-                            host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
-                              type: string
-                            httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
-                              items:
-                                description: HTTPHeader describes a custom header to
-                                  be used in HTTP probes
-                                properties:
-                                  name:
-                                    description: The header field name
-                                    type: string
-                                  value:
-                                    description: The header field value
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              description: Path to access on the HTTP server.
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                            scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          description: Minimum consecutive successes for the probe to
-                            be considered successful after having failed. Defaults to
-                            1. Must be 1 for liveness and startup. Minimum value is
-                            1.
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
-                          properties:
-                            host:
-                              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs to
-                            terminate gracefully upon probe failure. The grace period
-                            is the duration in seconds after the processes running in
-                            the pod are sent a termination signal and the time when
-                            the processes are forcibly halted with a kill signal. Set
-                            this value longer than the expected cleanup time for your
-                            process. If this value is nil, the pod's terminationGracePeriodSeconds
-                            will be used. Otherwise, this value overrides the value
-                            provided by the pod spec. Value must be non-negative integer.
-                            The value zero indicates stop immediately via the kill signal
-                            (no opportunity to shut down). This is a beta field and
-                            requires enabling ProbeTerminationGracePeriod feature gate.
-                            Minimum value is 1. spec.terminationGracePeriodSeconds is
-                            used if unset.
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                      type: object
-                    pdb:
-                      description: RedisPodDisruptionBudget configure a PodDisruptionBudget
-                        on the resource (leader/follower)
-                      properties:
-                        enabled:
-                          type: boolean
-                        maxUnavailable:
-                          format: int32
-                          type: integer
-                        minAvailable:
-                          format: int32
-                          type: integer
-                      type: object
-                    readinessProbe:
-                      description: Probe describes a health check to be performed against
-                        a container to determine whether it is alive or ready to receive
-                        traffic.
-                      properties:
-                        exec:
-                          description: Exec specifies the action to take.
-                          properties:
-                            command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          description: Minimum consecutive failures for the probe to
-                            be considered failed after having succeeded. Defaults to
-                            3. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        grpc:
-                          description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
-                            feature gate.
-                          properties:
-                            port:
-                              description: Port number of the gRPC service. Number must
-                                be in the range 1 to 65535.
-                              format: int32
-                              type: integer
-                            service:
-                              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        httpGet:
-                          description: HTTPGet specifies the http request to perform.
-                          properties:
-                            host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
-                              type: string
-                            httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
-                              items:
-                                description: HTTPHeader describes a custom header to
-                                  be used in HTTP probes
-                                properties:
-                                  name:
-                                    description: The header field name
-                                    type: string
-                                  value:
-                                    description: The header field value
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              description: Path to access on the HTTP server.
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                            scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          description: Minimum consecutive successes for the probe to
-                            be considered successful after having failed. Defaults to
-                            1. Must be 1 for liveness and startup. Minimum value is
-                            1.
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
-                          properties:
-                            host:
-                              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs to
-                            terminate gracefully upon probe failure. The grace period
-                            is the duration in seconds after the processes running in
-                            the pod are sent a termination signal and the time when
-                            the processes are forcibly halted with a kill signal. Set
-                            this value longer than the expected cleanup time for your
-                            process. If this value is nil, the pod's terminationGracePeriodSeconds
-                            will be used. Otherwise, this value overrides the value
-                            provided by the pod spec. Value must be non-negative integer.
-                            The value zero indicates stop immediately via the kill signal
-                            (no opportunity to shut down). This is a beta field and
-                            requires enabling ProbeTerminationGracePeriod feature gate.
-                            Minimum value is 1. spec.terminationGracePeriodSeconds is
-                            used if unset.
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                      type: object
-                    redisConfig:
-                      description: RedisConfig defines the external configuration of
-                        Redis
-                      properties:
-                        additionalRedisConfig:
-                          type: string
-                      type: object
-                    replicas:
-                      format: int32
-                      minimum: 3
-                      type: integer
-                  type: object
-                resources:
-                  description: ResourceRequirements describes the compute resource requirements.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                      type: object
-                  type: object
-                securityContext:
-                  description: PodSecurityContext holds pod-level security attributes
-                    and common container settings. Some fields are also present in container.securityContext.  Field
-                    values of container.securityContext take precedence over field values
-                    of PodSecurityContext.
-                  properties:
-                    fsGroup:
-                      description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
-                      type: string
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container process.
-                        Uses runtime default if unset. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to start
-                        the container if it does. If unset or false, no such validation
-                        will be performed. May also be set in SecurityContext.  If set
-                        in both SecurityContext and PodSecurityContext, the value specified
-                        in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container process.
-                        Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container. Note that this field cannot
-                        be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: The seccomp options to use by the containers in this
-                        pod. Note that this field cannot be set when spec.os.name is
-                        windows.
-                      properties:
-                        localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must be
-                            preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
-                          type: string
-                        type:
-                          description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary GID.  If
-                        unspecified, no groups will be added to any container. Note
-                        that this field cannot be set when spec.os.name is windows.
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                    sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used for
-                        the pod. Pods with unsupported sysctls (by the container runtime)
-                        might fail to launch. Note that this field cannot be set when
-                        spec.os.name is windows.
-                      items:
-                        description: Sysctl defines a kernel parameter to be set
-                        properties:
-                          name:
-                            description: Name of a property to set
-                            type: string
-                          value:
-                            description: Value of a property to set
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence. Note
-                        that this field cannot be set when spec.os.name is linux.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named by
-                            the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        hostProcess:
-                          description: HostProcess determines if a container should
-                            be run as a 'Host Process' container. This field is alpha-level
-                            and will only be honored by components that enable the WindowsHostProcessContainers
-                            feature flag. Setting this field without the feature flag
-                            will result in errors when validating the Pod. All of a
-                            Pod's containers must have the same effective HostProcess
-                            value (it is not allowed to have a mix of HostProcess containers
-                            and non-HostProcess containers).  In addition, if HostProcess
-                            is true then HostNetwork must also be set to true.
-                          type: boolean
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
-                  type: object
-                sidecars:
-                  items:
-                    description: Sidecar for each Redis pods
+                type: array
+              storage:
+                description: Storage is the inteface to add pvc and pv support in
+                  redis
+                properties:
+                  volumeClaimTemplate:
+                    description: PersistentVolumeClaim is a user's request for and
+                      claim to a persistent volume
                     properties:
-                      env:
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must be
-                                a C_IDENTIFIER.
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
+                          representation of an object. Servers should convert recognized
+                          schemas to the latest internal value, and may reject unrecognized
+                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST
+                          resource this object represents. Servers may infer this
+                          from the endpoint the client submits requests to. Cannot
+                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      metadata:
+                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      spec:
+                        description: 'Spec defines the desired characteristics of
+                          a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the desired access
+                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
                               type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in the
-                                        specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                      optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of the
-                                        exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select from.  Must
-                                        be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
+                            type: array
+                          dataSource:
+                            description: 'This field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                              * An existing PVC (PersistentVolumeClaim) If the provisioner
+                              or an external controller can support the specified
+                              data source, it will create a new volume based on the
+                              contents of the specified data source. If the AnyVolumeDataSource
+                              feature gate is enabled, this field will always have
+                              the same contents as the DataSourceRef field.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
                             - name
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        description: PullPolicy describes a policy for if/when to pull
-                          a container image
-                        type: string
-                      name:
-                        type: string
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                             type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    required:
-                      - image
-                      - name
-                    type: object
-                  type: array
-                storage:
-                  description: Storage is the inteface to add pvc and pv support in
-                    redis
-                  properties:
-                    volumeClaimTemplate:
-                      description: PersistentVolumeClaim is a user's request for and
-                        claim to a persistent volume
-                      properties:
-                        apiVersion:
-                          description: 'APIVersion defines the versioned schema of this
-                          representation of an object. Servers should convert recognized
-                          schemas to the latest internal value, and may reject unrecognized
-                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                          type: string
-                        kind:
-                          description: 'Kind is a string value representing the REST
-                          resource this object represents. Servers may infer this
-                          from the endpoint the client submits requests to. Cannot
-                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                          type: string
-                        metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                          type: object
-                        spec:
-                          description: 'Spec defines the desired characteristics of
-                          a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          properties:
-                            accessModes:
-                              description: 'AccessModes contains the desired access
-                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                              items:
-                                type: string
-                              type: array
-                            dataSource:
-                              description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                              * An existing PVC (PersistentVolumeClaim) If the provisioner
-                              or an external controller can support the specified
-                              data source, it will create a new volume based on the
-                              contents of the specified data source. If the AnyVolumeDataSource
-                              feature gate is enabled, this field will always have
-                              the same contents as the DataSourceRef field.'
-                              properties:
-                                apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
-                                  type: string
-                                kind:
-                                  description: Kind is the type of resource being referenced
-                                  type: string
-                                name:
-                                  description: Name is the name of resource being referenced
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                            dataSourceRef:
-                              description: 'Specifies the object from which to populate
+                          dataSourceRef:
+                            description: 'Specifies the object from which to populate
                               the volume with data, if a non-empty volume is desired.
                               This may be any local object from a non-empty API group
                               (non core object) or a PersistentVolumeClaim object.
@@ -3164,6119 +3164,261 @@ spec:
                               all values, and generates an error if a disallowed value
                               is   specified. (Alpha) Using this field requires the
                               AnyVolumeDataSource feature gate to be enabled.'
-                              properties:
-                                apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
-                                  type: string
-                                kind:
-                                  description: Kind is the type of resource being referenced
-                                  type: string
-                                name:
-                                  description: Name is the name of resource being referenced
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                            resources:
-                              description: 'Resources represents the minimum resources
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            description: 'Resources represents the minimum resources
                               the volume should have. If RecoverVolumeExpansionFailure
                               feature is enabled users are allowed to specify resource
                               requirements that are lower than previous value but
                               must still be higher than capacity recorded in the status
                               field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
                                   of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                  type: object
-                              type: object
-                            selector:
-                              description: A label query over volumes to consider for
-                                binding.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label selector
-                                    requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a selector
-                                      that contains values, a key, and an operator that
-                                      relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are In,
-                                          NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string values.
-                                          If the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator is
-                                          Exists or DoesNotExist, the values array must
-                                          be empty. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                      - key
-                                      - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value} pairs.
-                                    A single {key,value} in the matchLabels map is equivalent
-                                    to an element of matchExpressions, whose key field
-                                    is "key", the operator is "In", and the values array
-                                    contains only "value". The requirements are ANDed.
-                                  type: object
-                              type: object
-                            storageClassName:
-                              description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                              type: string
-                            volumeMode:
-                              description: volumeMode defines what type of volume is
-                                required by the claim. Value of Filesystem is implied
-                                when not included in claim spec.
-                              type: string
-                            volumeName:
-                              description: VolumeName is the binding reference to the
-                                PersistentVolume backing this claim.
-                              type: string
-                          type: object
-                        status:
-                          description: 'Status represents the current information/status
-                          of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          properties:
-                            accessModes:
-                              description: 'AccessModes contains the actual access modes
-                              the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                              items:
-                                type: string
-                              type: array
-                            allocatedResources:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: The storage resource within AllocatedResources
-                                tracks the capacity allocated to a PVC. It may be larger
-                                than the actual capacity when a volume expansion operation
-                                is requested. For storage quota, the larger value from
-                                allocatedResources and PVC.spec.resources is used. If
-                                allocatedResources is not set, PVC.spec.resources alone
-                                is used for quota calculation. If a volume expansion
-                                capacity request is lowered, allocatedResources is only
-                                lowered if there are no expansion operations in progress
-                                and if the actual volume capacity is equal or lower
-                                than the requested capacity. This is an alpha field
-                                and requires enabling RecoverVolumeExpansionFailure
-                                feature.
-                              type: object
-                            capacity:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: Represents the actual resources of the underlying
-                                volume.
-                              type: object
-                            conditions:
-                              description: Current Condition of persistent volume claim.
-                                If underlying persistent volume is being resized then
-                                the Condition will be set to 'ResizeStarted'.
-                              items:
-                                description: PersistentVolumeClaimCondition contails
-                                  details about state of pvc
-                                properties:
-                                  lastProbeTime:
-                                    description: Last time we probed the condition.
-                                    format: date-time
-                                    type: string
-                                  lastTransitionTime:
-                                    description: Last time the condition transitioned
-                                      from one status to another.
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Human-readable message indicating details
-                                      about last transition.
-                                    type: string
-                                  reason:
-                                    description: Unique, this should be a short, machine
-                                      understandable string that gives the reason for
-                                      condition's last transition. If it reports "ResizeStarted"
-                                      that means the underlying persistent volume is
-                                      being resized.
-                                    type: string
-                                  status:
-                                    type: string
-                                  type:
-                                    description: PersistentVolumeClaimConditionType
-                                      is a valid value of PersistentVolumeClaimCondition.Type
-                                    type: string
-                                required:
-                                  - status
-                                  - type
                                 type: object
-                              type: array
-                            phase:
-                              description: Phase represents the current phase of PersistentVolumeClaim.
-                              type: string
-                            resizeStatus:
-                              description: ResizeStatus stores status of resize operation.
-                                ResizeStatus is not set by default but when expansion
-                                is complete resizeStatus is set to empty string by resize
-                                controller or kubelet. This is an alpha field and requires
-                                enabling RecoverVolumeExpansionFailure feature.
-                              type: string
-                          type: object
-                      type: object
-                  type: object
-                tolerations:
-                  items:
-                    description: The pod this Toleration is attached to tolerates any
-                      taint that matches the triple <key,value,effect> using the matching
-                      operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match all
-                          values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to Equal.
-                          Exists is equivalent to wildcard for value, so that a pod
-                          can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default, it
-                          is not set, which means tolerate the taint forever (do not
-                          evict). Zero and negative values will be treated as 0 (evict
-                          immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              required:
-                - clusterSize
-                - kubernetesConfig
-              type: object
-            status:
-              description: RedisClusterStatus defines the observed state of RedisCluster
-              properties:
-                redisCluster:
-                  description: RedisClusterSpec defines the desired state of RedisCluster
-                  properties:
-                    TLS:
-                      description: TLS Configuration for redis instances
-                      properties:
-                        ca:
-                          type: string
-                        cert:
-                          type: string
-                        key:
-                          type: string
-  <<<<<<< HEAD
-name:
-  type: string
-type: object
-resources:
-  description: ResourceRequirements describes the compute resource
-    requirements.
-  properties:
-    limits:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-      type: object
-    requests:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-      type: object
-  type: object
-required:
-  - image
-type: object
-nodeSelector:
-  additionalProperties:
-    type: string
-  type: object
-priorityClassName:
-  type: string
-redisExporter:
-  description: RedisExporter interface will have the information for
-    redis exporter related stuff
-  properties:
-    enabled:
-      type: boolean
-    env:
-      items:
-        description: EnvVar represents an environment variable present
-          in a Container.
-        properties:
-          name:
-            description: Name of the environment variable. Must be a
-              C_IDENTIFIER.
-            type: string
-          value:
-            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previously defined environment variables in
-                            the container and any service environment variables. If
-                            a variable cannot be resolved, the reference in the input
-                            string will be unchanged. Double $$ are reduced to a single
-                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
-                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                            Escaped references will never be expanded, regardless
-                            of whether the variable exists or not. Defaults to "".'
-            type: string
-          valueFrom:
-            description: Source for the environment variable's value.
-              Cannot be used if value is not empty.
-            properties:
-              configMapKeyRef:
-                description: Selects a key of a ConfigMap.
-  =======
-secret:
-  description: Reference to secret which contains the certificates
-  properties:
-    defaultMode:
-      description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-      format: int32
-      type: integer
-    items:
-      description: If unspecified, each key-value pair in the
-        Data field of the referenced Secret will be projected
-        into the volume as a file whose name is the key and
-        content is the value. If specified, the listed keys
-        will be projected into the specified paths, and unlisted
-        keys will not be present. If a key is specified which
-        is not present in the Secret, the volume setup will
-        error unless it is marked optional. Paths must be relative
-        and may not contain the '..' path or start with '..'.
-      items:
-        description: Maps a string key to a path within a volume.
-  >>>>>>> upstream/master
-properties:
-  key:
-    description: The key to project.
-    type: string
-  mode:
-    description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-    format: int32
-    type: integer
-  path:
-    description: The relative path of the file to map
-      the key to. May not be an absolute path. May not
-      contain the path element '..'. May not start with
-      the string '..'.
-    type: string
-required:
-  - key
-  - path
-type: object
-  <<<<<<< HEAD
-fieldRef:
-  description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
-  properties:
-    apiVersion:
-      description: Version of the schema the FieldPath
-        is written in terms of, defaults to "v1".
-      type: string
-    fieldPath:
-      description: Path of the field to select in the
-        specified API version.
-      type: string
-  required:
-    - fieldPath
-  type: object
-resourceFieldRef:
-  description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
-  properties:
-    containerName:
-      description: 'Container name: required for volumes,
-                                    optional for env vars'
-      type: string
-    divisor:
-      anyOf:
-        - type: integer
-        - type: string
-      description: Specifies the output format of the
-        exposed resources, defaults to "1"
-      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-      x-kubernetes-int-or-string: true
-    resource:
-      description: 'Required: resource to select'
-      type: string
-  required:
-    - resource
-  type: object
-secretKeyRef:
-  description: Selects a key of a secret in the pod's
-    namespace
-  properties:
-    key:
-      description: The key of the secret to select from.  Must
-        be a valid secret key.
-      type: string
-    name:
-      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-      type: string
-    optional:
-      description: Specify whether the Secret or its key
-        must be defined
-      type: boolean
-  required:
-    - key
-  type: object
-type: object
-required:
-  - name
-type: object
-type: array
-image:
-  type: string
-imagePullPolicy:
-  description: PullPolicy describes a policy for if/when to pull
-    a container image
-  type: string
-resources:
-  description: ResourceRequirements describes the compute resource
-    requirements.
-  properties:
-    limits:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-      type: object
-    requests:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-  =======
-type: array
-optional:
-  description: Specify whether the Secret or its keys must
-    be defined
-  type: boolean
-secretName:
-  description: 'Name of the secret in the pod''s namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-  type: string
-  >>>>>>> upstream/master
-type: object
-required:
-  - secret
-type: object
-  <<<<<<< HEAD
-required:
-  - image
-type: object
-redisFollower:
-  description: RedisFollower interface will have the redis follower
-    configuration
-  properties:
-    affinity:
-      description: Affinity is a group of affinity scheduling rules.
-      properties:
-        nodeAffinity:
-          description: Describes node affinity scheduling rules for
-            the pod.
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule pods
-                to nodes that satisfy the affinity expressions specified
-                by this field, but it may choose a node that violates
-                one or more of the expressions. The node that is most
-                preferred is the one with the greatest sum of weights,
-                i.e. for each node that meets all of the scheduling
-                requirements (resource request, requiredDuringScheduling
-                affinity expressions, etc.), compute a sum by iterating
-                through the elements of this field and adding "weight"
-                to the sum if the node matches the corresponding matchExpressions;
-                the node(s) with the highest sum are the most preferred.
-              items:
-                description: An empty preferred scheduling term matches
-                  all objects with implicit weight 0 (i.e. it's a no-op).
-                  A null preferred scheduling term matches no objects
-                  (i.e. is also a no-op).
-                properties:
-                  preference:
-                    description: A node selector term, associated with
-                      the corresponding weight.
-                    properties:
-                      matchExpressions:
-                        description: A list of node selector requirements
-                          by node's labels.
-                        items:
-                          description: A node selector requirement is
-                            a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: The label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn, the
-                                values array must be non-empty. If the
-                                operator is Exists or DoesNotExist,
-                                the values array must be empty. If the
-                                operator is Gt or Lt, the values array
-                                must have a single element, which will
-                                be interpreted as an integer. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements
-                          by node's fields.
-                        items:
-                          description: A node selector requirement is
-                            a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: The label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn, the
-                                values array must be non-empty. If the
-                                operator is Exists or DoesNotExist,
-                                the values array must be empty. If the
-                                operator is Gt or Lt, the values array
-                                must have a single element, which will
-                                be interpreted as an integer. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                    type: object
-                  weight:
-                    description: Weight associated with matching the
-                      corresponding nodeSelectorTerm, in the range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - preference
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the affinity requirements specified by
-                this field are not met at scheduling time, the pod will
-                not be scheduled onto the node. If the affinity requirements
-                specified by this field cease to be met at some point
-                during pod execution (e.g. due to an update), the system
-                may or may not try to eventually evict the pod from
-                its node.
-              properties:
-                nodeSelectorTerms:
-                  description: Required. A list of node selector terms.
-                    The terms are ORed.
-                  items:
-                    description: A null or empty node selector term
-                      matches no objects. The requirements of them are
-                      ANDed. The TopologySelectorTerm type implements
-                      a subset of the NodeSelectorTerm.
-                    properties:
-                      matchExpressions:
-                        description: A list of node selector requirements
-                          by node's labels.
-                        items:
-                          description: A node selector requirement is
-                            a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: The label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn, the
-                                values array must be non-empty. If the
-                                operator is Exists or DoesNotExist,
-                                the values array must be empty. If the
-                                operator is Gt or Lt, the values array
-                                must have a single element, which will
-                                be interpreted as an integer. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements
-                          by node's fields.
-                        items:
-                          description: A node selector requirement is
-                            a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: The label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn, the
-                                values array must be non-empty. If the
-                                operator is Exists or DoesNotExist,
-                                the values array must be empty. If the
-                                operator is Gt or Lt, the values array
-                                must have a single element, which will
-                                be interpreted as an integer. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                    type: object
-                  type: array
-              required:
-                - nodeSelectorTerms
-              type: object
-          type: object
-        podAffinity:
-          description: Describes pod affinity scheduling rules (e.g.
-            co-locate this pod in the same node, zone, etc. as some
-            other pod(s)).
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule pods
-                to nodes that satisfy the affinity expressions specified
-                by this field, but it may choose a node that violates
-                one or more of the expressions. The node that is most
-                preferred is the one with the greatest sum of weights,
-                i.e. for each node that meets all of the scheduling
-                requirements (resource request, requiredDuringScheduling
-                affinity expressions, etc.), compute a sum by iterating
-                through the elements of this field and adding "weight"
-                to the sum if the node has pods which matches the corresponding
-                podAffinityTerm; the node(s) with the highest sum are
-                the most preferred.
-              items:
-                description: The weights of all of the matched WeightedPodAffinityTerm
-                  fields are added per-node to find the most preferred
-                  node(s)
-                properties:
-                  podAffinityTerm:
-                    description: Required. A pod affinity term, associated
-                      with the corresponding weight.
-                    properties:
-                      labelSelector:
-                        description: A label query over a set of resources,
-                          in this case pods.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The requirements
-                              are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key
-                                    that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a
-                                    key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists
-                                    and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of
-                                    string values. If the operator is
-                                    In or NotIn, the values array must
-                                    be non-empty. If the operator is
-                                    Exists or DoesNotExist, the values
-                                    array must be empty. This array
-                                    is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value}
-                              pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      namespaceSelector:
-                        description: A label query over the set of namespaces
-                          that the term applies to. The term is applied
-                          to the union of the namespaces selected by
-                          this field and the ones listed in the namespaces
-                          field. null selector and null or empty namespaces
-                          list means "this pod's namespace". An empty
-                          selector ({}) matches all namespaces. This
-                          field is beta-level and is only honored when
-                          PodAffinityNamespaceSelector feature is enabled.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The requirements
-                              are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key
-                                    that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a
-                                    key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists
-                                    and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of
-                                    string values. If the operator is
-                                    In or NotIn, the values array must
-                                    be non-empty. If the operator is
-                                    Exists or DoesNotExist, the values
-                                    array must be empty. This array
-                                    is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value}
-                              pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      namespaces:
-                        description: namespaces specifies a static list
-                          of namespace names that the term applies to.
-                          The term is applied to the union of the namespaces
-                          listed in this field and the ones selected
-                          by namespaceSelector. null or empty namespaces
-                          list and null namespaceSelector means "this
-                          pod's namespace"
-                        items:
-                          type: string
-                        type: array
-                      topologyKey:
-                        description: This pod should be co-located (affinity)
-                          or not co-located (anti-affinity) with the
-                          pods matching the labelSelector in the specified
-                          namespaces, where co-located is defined as
-                          running on a node whose value of the label
-                          with key topologyKey matches that of any node
-                          on which any of the selected pods is running.
-                          Empty topologyKey is not allowed.
-                        type: string
-                    required:
-                      - topologyKey
-                    type: object
-                  weight:
-                    description: weight associated with matching the
-                      corresponding podAffinityTerm, in the range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - podAffinityTerm
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the affinity requirements specified by
-                this field are not met at scheduling time, the pod will
-                not be scheduled onto the node. If the affinity requirements
-                specified by this field cease to be met at some point
-                during pod execution (e.g. due to a pod label update),
-                the system may or may not try to eventually evict the
-                pod from its node. When there are multiple elements,
-                the lists of nodes corresponding to each podAffinityTerm
-                are intersected, i.e. all terms must be satisfied.
-              items:
-                description: Defines a set of pods (namely those matching
-                  the labelSelector relative to the given namespace(s))
-                  that this pod should be co-located (affinity) or not
-                  co-located (anti-affinity) with, where co-located
-                  is defined as running on a node whose value of the
-                  label with key <topologyKey> matches that of any node
-                  on which a pod of the set of pods is running
-                properties:
-                  labelSelector:
-                    description: A label query over a set of resources,
-                      in this case pods.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label
-                          selector requirements. The requirements are
-                          ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: key is the label key that
-                                the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's
-                                relationship to a set of values. Valid
-                                operators are In, NotIn, Exists and
-                                DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string
-                                values. If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This
-                                array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator is
-                          "In", and the values array contains only "value".
-                          The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaceSelector:
-                    description: A label query over the set of namespaces
-                      that the term applies to. The term is applied
-                      to the union of the namespaces selected by this
-                      field and the ones listed in the namespaces field.
-                      null selector and null or empty namespaces list
-                      means "this pod's namespace". An empty selector
-                      ({}) matches all namespaces. This field is beta-level
-                      and is only honored when PodAffinityNamespaceSelector
-                      feature is enabled.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label
-                          selector requirements. The requirements are
-                          ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: key is the label key that
-                                the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's
-                                relationship to a set of values. Valid
-                                operators are In, NotIn, Exists and
-                                DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string
-                                values. If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This
-                                array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator is
-                          "In", and the values array contains only "value".
-                          The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaces:
-                    description: namespaces specifies a static list
-                      of namespace names that the term applies to. The
-                      term is applied to the union of the namespaces
-                      listed in this field and the ones selected by
-                      namespaceSelector. null or empty namespaces list
-                      and null namespaceSelector means "this pod's namespace"
-                    items:
-                      type: string
-                    type: array
-                  topologyKey:
-                    description: This pod should be co-located (affinity)
-                      or not co-located (anti-affinity) with the pods
-                      matching the labelSelector in the specified namespaces,
-                      where co-located is defined as running on a node
-                      whose value of the label with key topologyKey
-                      matches that of any node on which any of the selected
-                      pods is running. Empty topologyKey is not allowed.
-                    type: string
-                required:
-                  - topologyKey
-                type: object
-              type: array
-          type: object
-        podAntiAffinity:
-          description: Describes pod anti-affinity scheduling rules
-            (e.g. avoid putting this pod in the same node, zone, etc.
-            as some other pod(s)).
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule pods
-                to nodes that satisfy the anti-affinity expressions
-                specified by this field, but it may choose a node that
-                violates one or more of the expressions. The node that
-                is most preferred is the one with the greatest sum of
-                weights, i.e. for each node that meets all of the scheduling
-                requirements (resource request, requiredDuringScheduling
-                anti-affinity expressions, etc.), compute a sum by iterating
-                through the elements of this field and adding "weight"
-                to the sum if the node has pods which matches the corresponding
-                podAffinityTerm; the node(s) with the highest sum are
-                the most preferred.
-              items:
-                description: The weights of all of the matched WeightedPodAffinityTerm
-                  fields are added per-node to find the most preferred
-                  node(s)
-                properties:
-                  podAffinityTerm:
-                    description: Required. A pod affinity term, associated
-                      with the corresponding weight.
-                    properties:
-                      labelSelector:
-                        description: A label query over a set of resources,
-                          in this case pods.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The requirements
-                              are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key
-                                    that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a
-                                    key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists
-                                    and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of
-                                    string values. If the operator is
-                                    In or NotIn, the values array must
-                                    be non-empty. If the operator is
-                                    Exists or DoesNotExist, the values
-                                    array must be empty. This array
-                                    is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value}
-                              pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      namespaceSelector:
-                        description: A label query over the set of namespaces
-                          that the term applies to. The term is applied
-                          to the union of the namespaces selected by
-                          this field and the ones listed in the namespaces
-                          field. null selector and null or empty namespaces
-                          list means "this pod's namespace". An empty
-                          selector ({}) matches all namespaces. This
-                          field is beta-level and is only honored when
-                          PodAffinityNamespaceSelector feature is enabled.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The requirements
-                              are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key
-                                    that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a
-                                    key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists
-                                    and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of
-                                    string values. If the operator is
-                                    In or NotIn, the values array must
-                                    be non-empty. If the operator is
-                                    Exists or DoesNotExist, the values
-                                    array must be empty. This array
-                                    is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value}
-                              pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      namespaces:
-                        description: namespaces specifies a static list
-                          of namespace names that the term applies to.
-                          The term is applied to the union of the namespaces
-                          listed in this field and the ones selected
-                          by namespaceSelector. null or empty namespaces
-                          list and null namespaceSelector means "this
-                          pod's namespace"
-                        items:
-                          type: string
-                        type: array
-                      topologyKey:
-                        description: This pod should be co-located (affinity)
-                          or not co-located (anti-affinity) with the
-                          pods matching the labelSelector in the specified
-                          namespaces, where co-located is defined as
-                          running on a node whose value of the label
-                          with key topologyKey matches that of any node
-                          on which any of the selected pods is running.
-                          Empty topologyKey is not allowed.
-                        type: string
-                    required:
-                      - topologyKey
-                    type: object
-                  weight:
-                    description: weight associated with matching the
-                      corresponding podAffinityTerm, in the range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - podAffinityTerm
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the anti-affinity requirements specified
-                by this field are not met at scheduling time, the pod
-                will not be scheduled onto the node. If the anti-affinity
-                requirements specified by this field cease to be met
-                at some point during pod execution (e.g. due to a pod
-                label update), the system may or may not try to eventually
-                evict the pod from its node. When there are multiple
-                elements, the lists of nodes corresponding to each podAffinityTerm
-                are intersected, i.e. all terms must be satisfied.
-              items:
-                description: Defines a set of pods (namely those matching
-                  the labelSelector relative to the given namespace(s))
-                  that this pod should be co-located (affinity) or not
-                  co-located (anti-affinity) with, where co-located
-                  is defined as running on a node whose value of the
-                  label with key <topologyKey> matches that of any node
-                  on which a pod of the set of pods is running
-                properties:
-                  labelSelector:
-                    description: A label query over a set of resources,
-                      in this case pods.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label
-                          selector requirements. The requirements are
-                          ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: key is the label key that
-                                the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's
-                                relationship to a set of values. Valid
-                                operators are In, NotIn, Exists and
-                                DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string
-                                values. If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This
-                                array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator is
-                          "In", and the values array contains only "value".
-                          The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaceSelector:
-                    description: A label query over the set of namespaces
-                      that the term applies to. The term is applied
-                      to the union of the namespaces selected by this
-                      field and the ones listed in the namespaces field.
-                      null selector and null or empty namespaces list
-                      means "this pod's namespace". An empty selector
-                      ({}) matches all namespaces. This field is beta-level
-                      and is only honored when PodAffinityNamespaceSelector
-                      feature is enabled.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label
-                          selector requirements. The requirements are
-                          ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: key is the label key that
-                                the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's
-                                relationship to a set of values. Valid
-                                operators are In, NotIn, Exists and
-                                DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string
-                                values. If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This
-                                array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator is
-                          "In", and the values array contains only "value".
-                          The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaces:
-                    description: namespaces specifies a static list
-                      of namespace names that the term applies to. The
-                      term is applied to the union of the namespaces
-                      listed in this field and the ones selected by
-                      namespaceSelector. null or empty namespaces list
-                      and null namespaceSelector means "this pod's namespace"
-                    items:
-                      type: string
-                    type: array
-                  topologyKey:
-                    description: This pod should be co-located (affinity)
-                      or not co-located (anti-affinity) with the pods
-                      matching the labelSelector in the specified namespaces,
-                      where co-located is defined as running on a node
-                      whose value of the label with key topologyKey
-                      matches that of any node on which any of the selected
-                      pods is running. Empty topologyKey is not allowed.
-                    type: string
-                required:
-                  - topologyKey
-                type: object
-              type: array
-          type: object
-      type: object
-    livenessProbe:
-      description: Probe describes a health check to be performed against
-        a container to determine whether it is alive or ready to receive
-        traffic.
-      properties:
-        exec:
-          description: Exec specifies the action to take.
-          properties:
-            command:
-              description: Command is the command line to execute inside
-                the container, the working directory for the command  is
-                root ('/') in the container's filesystem. The command
-                is simply exec'd, it is not run inside a shell, so traditional
-                shell instructions ('|', etc) won't work. To use a shell,
-                you need to explicitly call out to that shell. Exit
-                status of 0 is treated as live/healthy and non-zero
-                is unhealthy.
-              items:
-                type: string
-              type: array
-          type: object
-        failureThreshold:
-          description: Minimum consecutive failures for the probe to
-            be considered failed after having succeeded. Defaults to
-            3. Minimum value is 1.
-          format: int32
-          type: integer
-        grpc:
-          description: GRPC specifies an action involving a GRPC port.
-            This is an alpha field and requires enabling GRPCContainerProbe
-            feature gate.
-          properties:
-            port:
-              description: Port number of the gRPC service. Number must
-                be in the range 1 to 65535.
-              format: int32
-              type: integer
-            service:
-              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-              type: string
-          required:
-            - port
-          type: object
-        httpGet:
-          description: HTTPGet specifies the http request to perform.
-          properties:
-            host:
-              description: Host name to connect to, defaults to the
-                pod IP. You probably want to set "Host" in httpHeaders
-                instead.
-              type: string
-            httpHeaders:
-              description: Custom headers to set in the request. HTTP
-                allows repeated headers.
-              items:
-                description: HTTPHeader describes a custom header to
-                  be used in HTTP probes
-                properties:
-                  name:
-                    description: The header field name
-                    type: string
-                  value:
-                    description: The header field value
-                    type: string
-                required:
-                  - name
-                  - value
-                type: object
-              type: array
-            path:
-              description: Path to access on the HTTP server.
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Name or number of the port to access on the
-                container. Number must be in the range 1 to 65535. Name
-                must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-            scheme:
-              description: Scheme to use for connecting to the host.
-                Defaults to HTTP.
-              type: string
-          required:
-            - port
-          type: object
-        initialDelaySeconds:
-          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-        periodSeconds:
-          description: How often (in seconds) to perform the probe.
-            Default to 10 seconds. Minimum value is 1.
-          format: int32
-          type: integer
-        successThreshold:
-          description: Minimum consecutive successes for the probe to
-            be considered successful after having failed. Defaults to
-            1. Must be 1 for liveness and startup. Minimum value is
-            1.
-          format: int32
-          type: integer
-        tcpSocket:
-          description: TCPSocket specifies an action involving a TCP
-            port.
-          properties:
-            host:
-              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Number or name of the port to access on the
-                container. Number must be in the range 1 to 65535. Name
-                must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-          required:
-            - port
-          type: object
-        terminationGracePeriodSeconds:
-          description: Optional duration in seconds the pod needs to
-            terminate gracefully upon probe failure. The grace period
-            is the duration in seconds after the processes running in
-            the pod are sent a termination signal and the time when
-            the processes are forcibly halted with a kill signal. Set
-            this value longer than the expected cleanup time for your
-            process. If this value is nil, the pod's terminationGracePeriodSeconds
-            will be used. Otherwise, this value overrides the value
-            provided by the pod spec. Value must be non-negative integer.
-            The value zero indicates stop immediately via the kill signal
-            (no opportunity to shut down). This is a beta field and
-            requires enabling ProbeTerminationGracePeriod feature gate.
-            Minimum value is 1. spec.terminationGracePeriodSeconds is
-            used if unset.
-          format: int64
-          type: integer
-        timeoutSeconds:
-          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-      type: object
-    pdb:
-      description: RedisPodDisruptionBudget configure a PodDisruptionBudget
-        on the resource (leader/follower)
-      properties:
-        enabled:
-          type: boolean
-        maxUnavailable:
-          format: int32
-          type: integer
-        minAvailable:
-          format: int32
-          type: integer
-      type: object
-    readinessProbe:
-      description: Probe describes a health check to be performed against
-        a container to determine whether it is alive or ready to receive
-        traffic.
-      properties:
-        exec:
-          description: Exec specifies the action to take.
-          properties:
-            command:
-              description: Command is the command line to execute inside
-                the container, the working directory for the command  is
-                root ('/') in the container's filesystem. The command
-                is simply exec'd, it is not run inside a shell, so traditional
-                shell instructions ('|', etc) won't work. To use a shell,
-                you need to explicitly call out to that shell. Exit
-                status of 0 is treated as live/healthy and non-zero
-                is unhealthy.
-              items:
-                type: string
-              type: array
-          type: object
-        failureThreshold:
-          description: Minimum consecutive failures for the probe to
-            be considered failed after having succeeded. Defaults to
-            3. Minimum value is 1.
-          format: int32
-          type: integer
-        grpc:
-          description: GRPC specifies an action involving a GRPC port.
-            This is an alpha field and requires enabling GRPCContainerProbe
-            feature gate.
-          properties:
-            port:
-              description: Port number of the gRPC service. Number must
-                be in the range 1 to 65535.
-              format: int32
-              type: integer
-            service:
-              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-              type: string
-          required:
-            - port
-          type: object
-        httpGet:
-          description: HTTPGet specifies the http request to perform.
-          properties:
-            host:
-              description: Host name to connect to, defaults to the
-                pod IP. You probably want to set "Host" in httpHeaders
-                instead.
-              type: string
-            httpHeaders:
-              description: Custom headers to set in the request. HTTP
-                allows repeated headers.
-              items:
-                description: HTTPHeader describes a custom header to
-                  be used in HTTP probes
-                properties:
-                  name:
-                    description: The header field name
-                    type: string
-                  value:
-                    description: The header field value
-                    type: string
-                required:
-                  - name
-                  - value
-                type: object
-              type: array
-            path:
-              description: Path to access on the HTTP server.
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Name or number of the port to access on the
-                container. Number must be in the range 1 to 65535. Name
-                must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-            scheme:
-              description: Scheme to use for connecting to the host.
-                Defaults to HTTP.
-              type: string
-          required:
-            - port
-          type: object
-        initialDelaySeconds:
-          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-        periodSeconds:
-          description: How often (in seconds) to perform the probe.
-            Default to 10 seconds. Minimum value is 1.
-          format: int32
-          type: integer
-        successThreshold:
-          description: Minimum consecutive successes for the probe to
-            be considered successful after having failed. Defaults to
-            1. Must be 1 for liveness and startup. Minimum value is
-            1.
-          format: int32
-          type: integer
-        tcpSocket:
-          description: TCPSocket specifies an action involving a TCP
-            port.
-          properties:
-            host:
-              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Number or name of the port to access on the
-                container. Number must be in the range 1 to 65535. Name
-                must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-          required:
-            - port
-          type: object
-        terminationGracePeriodSeconds:
-          description: Optional duration in seconds the pod needs to
-            terminate gracefully upon probe failure. The grace period
-            is the duration in seconds after the processes running in
-            the pod are sent a termination signal and the time when
-            the processes are forcibly halted with a kill signal. Set
-            this value longer than the expected cleanup time for your
-            process. If this value is nil, the pod's terminationGracePeriodSeconds
-            will be used. Otherwise, this value overrides the value
-            provided by the pod spec. Value must be non-negative integer.
-            The value zero indicates stop immediately via the kill signal
-            (no opportunity to shut down). This is a beta field and
-            requires enabling ProbeTerminationGracePeriod feature gate.
-            Minimum value is 1. spec.terminationGracePeriodSeconds is
-            used if unset.
-          format: int64
-          type: integer
-        timeoutSeconds:
-          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-      type: object
-    redisConfig:
-      description: RedisConfig defines the external configuration of
-        Redis
-      properties:
-        additionalRedisConfig:
-          type: string
-      type: object
-    replicas:
-      format: int32
-      type: integer
-  type: object
-redisLeader:
-  description: RedisLeader interface will have the redis leader configuration
-  properties:
-    affinity:
-      description: Affinity is a group of affinity scheduling rules.
-      properties:
-        nodeAffinity:
-          description: Describes node affinity scheduling rules for
-            the pod.
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule pods
-                to nodes that satisfy the affinity expressions specified
-                by this field, but it may choose a node that violates
-                one or more of the expressions. The node that is most
-                preferred is the one with the greatest sum of weights,
-                i.e. for each node that meets all of the scheduling
-                requirements (resource request, requiredDuringScheduling
-                affinity expressions, etc.), compute a sum by iterating
-                through the elements of this field and adding "weight"
-                to the sum if the node matches the corresponding matchExpressions;
-                the node(s) with the highest sum are the most preferred.
-              items:
-                description: An empty preferred scheduling term matches
-                  all objects with implicit weight 0 (i.e. it's a no-op).
-                  A null preferred scheduling term matches no objects
-                  (i.e. is also a no-op).
-                properties:
-                  preference:
-                    description: A node selector term, associated with
-                      the corresponding weight.
-                    properties:
-                      matchExpressions:
-                        description: A list of node selector requirements
-                          by node's labels.
-                        items:
-                          description: A node selector requirement is
-                            a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: The label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn, the
-                                values array must be non-empty. If the
-                                operator is Exists or DoesNotExist,
-                                the values array must be empty. If the
-                                operator is Gt or Lt, the values array
-                                must have a single element, which will
-                                be interpreted as an integer. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements
-                          by node's fields.
-                        items:
-                          description: A node selector requirement is
-                            a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: The label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn, the
-                                values array must be non-empty. If the
-                                operator is Exists or DoesNotExist,
-                                the values array must be empty. If the
-                                operator is Gt or Lt, the values array
-                                must have a single element, which will
-                                be interpreted as an integer. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                    type: object
-                  weight:
-                    description: Weight associated with matching the
-                      corresponding nodeSelectorTerm, in the range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - preference
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the affinity requirements specified by
-                this field are not met at scheduling time, the pod will
-                not be scheduled onto the node. If the affinity requirements
-                specified by this field cease to be met at some point
-                during pod execution (e.g. due to an update), the system
-                may or may not try to eventually evict the pod from
-                its node.
-              properties:
-                nodeSelectorTerms:
-                  description: Required. A list of node selector terms.
-                    The terms are ORed.
-                  items:
-                    description: A null or empty node selector term
-                      matches no objects. The requirements of them are
-                      ANDed. The TopologySelectorTerm type implements
-                      a subset of the NodeSelectorTerm.
-                    properties:
-                      matchExpressions:
-                        description: A list of node selector requirements
-                          by node's labels.
-                        items:
-                          description: A node selector requirement is
-                            a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: The label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn, the
-                                values array must be non-empty. If the
-                                operator is Exists or DoesNotExist,
-                                the values array must be empty. If the
-                                operator is Gt or Lt, the values array
-                                must have a single element, which will
-                                be interpreted as an integer. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements
-                          by node's fields.
-                        items:
-                          description: A node selector requirement is
-                            a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: The label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn, the
-                                values array must be non-empty. If the
-                                operator is Exists or DoesNotExist,
-                                the values array must be empty. If the
-                                operator is Gt or Lt, the values array
-                                must have a single element, which will
-                                be interpreted as an integer. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                    type: object
-                  type: array
-              required:
-                - nodeSelectorTerms
-              type: object
-          type: object
-        podAffinity:
-          description: Describes pod affinity scheduling rules (e.g.
-            co-locate this pod in the same node, zone, etc. as some
-            other pod(s)).
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule pods
-                to nodes that satisfy the affinity expressions specified
-                by this field, but it may choose a node that violates
-                one or more of the expressions. The node that is most
-                preferred is the one with the greatest sum of weights,
-                i.e. for each node that meets all of the scheduling
-                requirements (resource request, requiredDuringScheduling
-                affinity expressions, etc.), compute a sum by iterating
-                through the elements of this field and adding "weight"
-                to the sum if the node has pods which matches the corresponding
-                podAffinityTerm; the node(s) with the highest sum are
-                the most preferred.
-              items:
-                description: The weights of all of the matched WeightedPodAffinityTerm
-                  fields are added per-node to find the most preferred
-                  node(s)
-                properties:
-                  podAffinityTerm:
-                    description: Required. A pod affinity term, associated
-                      with the corresponding weight.
-                    properties:
-                      labelSelector:
-                        description: A label query over a set of resources,
-                          in this case pods.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The requirements
-                              are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key
-                                    that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a
-                                    key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists
-                                    and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of
-                                    string values. If the operator is
-                                    In or NotIn, the values array must
-                                    be non-empty. If the operator is
-                                    Exists or DoesNotExist, the values
-                                    array must be empty. This array
-                                    is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value}
-                              pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      namespaceSelector:
-                        description: A label query over the set of namespaces
-                          that the term applies to. The term is applied
-                          to the union of the namespaces selected by
-                          this field and the ones listed in the namespaces
-                          field. null selector and null or empty namespaces
-                          list means "this pod's namespace". An empty
-                          selector ({}) matches all namespaces. This
-                          field is beta-level and is only honored when
-                          PodAffinityNamespaceSelector feature is enabled.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The requirements
-                              are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key
-                                    that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a
-                                    key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists
-                                    and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of
-                                    string values. If the operator is
-                                    In or NotIn, the values array must
-                                    be non-empty. If the operator is
-                                    Exists or DoesNotExist, the values
-                                    array must be empty. This array
-                                    is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value}
-                              pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      namespaces:
-                        description: namespaces specifies a static list
-                          of namespace names that the term applies to.
-                          The term is applied to the union of the namespaces
-                          listed in this field and the ones selected
-                          by namespaceSelector. null or empty namespaces
-                          list and null namespaceSelector means "this
-                          pod's namespace"
-                        items:
-                          type: string
-                        type: array
-                      topologyKey:
-                        description: This pod should be co-located (affinity)
-                          or not co-located (anti-affinity) with the
-                          pods matching the labelSelector in the specified
-                          namespaces, where co-located is defined as
-                          running on a node whose value of the label
-                          with key topologyKey matches that of any node
-                          on which any of the selected pods is running.
-                          Empty topologyKey is not allowed.
-                        type: string
-                    required:
-                      - topologyKey
-                    type: object
-                  weight:
-                    description: weight associated with matching the
-                      corresponding podAffinityTerm, in the range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - podAffinityTerm
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the affinity requirements specified by
-                this field are not met at scheduling time, the pod will
-                not be scheduled onto the node. If the affinity requirements
-                specified by this field cease to be met at some point
-                during pod execution (e.g. due to a pod label update),
-                the system may or may not try to eventually evict the
-                pod from its node. When there are multiple elements,
-                the lists of nodes corresponding to each podAffinityTerm
-                are intersected, i.e. all terms must be satisfied.
-              items:
-                description: Defines a set of pods (namely those matching
-                  the labelSelector relative to the given namespace(s))
-                  that this pod should be co-located (affinity) or not
-                  co-located (anti-affinity) with, where co-located
-                  is defined as running on a node whose value of the
-                  label with key <topologyKey> matches that of any node
-                  on which a pod of the set of pods is running
-                properties:
-                  labelSelector:
-                    description: A label query over a set of resources,
-                      in this case pods.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label
-                          selector requirements. The requirements are
-                          ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: key is the label key that
-                                the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's
-                                relationship to a set of values. Valid
-                                operators are In, NotIn, Exists and
-                                DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string
-                                values. If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This
-                                array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator is
-                          "In", and the values array contains only "value".
-                          The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaceSelector:
-                    description: A label query over the set of namespaces
-                      that the term applies to. The term is applied
-                      to the union of the namespaces selected by this
-                      field and the ones listed in the namespaces field.
-                      null selector and null or empty namespaces list
-                      means "this pod's namespace". An empty selector
-                      ({}) matches all namespaces. This field is beta-level
-                      and is only honored when PodAffinityNamespaceSelector
-                      feature is enabled.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label
-                          selector requirements. The requirements are
-                          ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: key is the label key that
-                                the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's
-                                relationship to a set of values. Valid
-                                operators are In, NotIn, Exists and
-                                DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string
-                                values. If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This
-                                array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator is
-                          "In", and the values array contains only "value".
-                          The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaces:
-                    description: namespaces specifies a static list
-                      of namespace names that the term applies to. The
-                      term is applied to the union of the namespaces
-                      listed in this field and the ones selected by
-                      namespaceSelector. null or empty namespaces list
-                      and null namespaceSelector means "this pod's namespace"
-                    items:
-                      type: string
-                    type: array
-                  topologyKey:
-                    description: This pod should be co-located (affinity)
-                      or not co-located (anti-affinity) with the pods
-                      matching the labelSelector in the specified namespaces,
-                      where co-located is defined as running on a node
-                      whose value of the label with key topologyKey
-                      matches that of any node on which any of the selected
-                      pods is running. Empty topologyKey is not allowed.
-                    type: string
-                required:
-                  - topologyKey
-                type: object
-              type: array
-          type: object
-        podAntiAffinity:
-          description: Describes pod anti-affinity scheduling rules
-            (e.g. avoid putting this pod in the same node, zone, etc.
-            as some other pod(s)).
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule pods
-                to nodes that satisfy the anti-affinity expressions
-                specified by this field, but it may choose a node that
-                violates one or more of the expressions. The node that
-                is most preferred is the one with the greatest sum of
-                weights, i.e. for each node that meets all of the scheduling
-                requirements (resource request, requiredDuringScheduling
-                anti-affinity expressions, etc.), compute a sum by iterating
-                through the elements of this field and adding "weight"
-                to the sum if the node has pods which matches the corresponding
-                podAffinityTerm; the node(s) with the highest sum are
-                the most preferred.
-              items:
-                description: The weights of all of the matched WeightedPodAffinityTerm
-                  fields are added per-node to find the most preferred
-                  node(s)
-                properties:
-                  podAffinityTerm:
-                    description: Required. A pod affinity term, associated
-                      with the corresponding weight.
-                    properties:
-                      labelSelector:
-                        description: A label query over a set of resources,
-                          in this case pods.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The requirements
-                              are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key
-                                    that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a
-                                    key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists
-                                    and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of
-                                    string values. If the operator is
-                                    In or NotIn, the values array must
-                                    be non-empty. If the operator is
-                                    Exists or DoesNotExist, the values
-                                    array must be empty. This array
-                                    is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value}
-                              pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      namespaceSelector:
-                        description: A label query over the set of namespaces
-                          that the term applies to. The term is applied
-                          to the union of the namespaces selected by
-                          this field and the ones listed in the namespaces
-                          field. null selector and null or empty namespaces
-                          list means "this pod's namespace". An empty
-                          selector ({}) matches all namespaces. This
-                          field is beta-level and is only honored when
-                          PodAffinityNamespaceSelector feature is enabled.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The requirements
-                              are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key
-                                    that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a
-                                    key's relationship to a set of values.
-                                    Valid operators are In, NotIn, Exists
-                                    and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of
-                                    string values. If the operator is
-                                    In or NotIn, the values array must
-                                    be non-empty. If the operator is
-                                    Exists or DoesNotExist, the values
-                                    array must be empty. This array
-                                    is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value}
-                              pairs. A single {key,value} in the matchLabels
-                              map is equivalent to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      namespaces:
-                        description: namespaces specifies a static list
-                          of namespace names that the term applies to.
-                          The term is applied to the union of the namespaces
-                          listed in this field and the ones selected
-                          by namespaceSelector. null or empty namespaces
-                          list and null namespaceSelector means "this
-                          pod's namespace"
-                        items:
-                          type: string
-                        type: array
-                      topologyKey:
-                        description: This pod should be co-located (affinity)
-                          or not co-located (anti-affinity) with the
-                          pods matching the labelSelector in the specified
-                          namespaces, where co-located is defined as
-                          running on a node whose value of the label
-                          with key topologyKey matches that of any node
-                          on which any of the selected pods is running.
-                          Empty topologyKey is not allowed.
-                        type: string
-                    required:
-                      - topologyKey
-                    type: object
-                  weight:
-                    description: weight associated with matching the
-                      corresponding podAffinityTerm, in the range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - podAffinityTerm
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the anti-affinity requirements specified
-                by this field are not met at scheduling time, the pod
-                will not be scheduled onto the node. If the anti-affinity
-                requirements specified by this field cease to be met
-                at some point during pod execution (e.g. due to a pod
-                label update), the system may or may not try to eventually
-                evict the pod from its node. When there are multiple
-                elements, the lists of nodes corresponding to each podAffinityTerm
-                are intersected, i.e. all terms must be satisfied.
-              items:
-                description: Defines a set of pods (namely those matching
-                  the labelSelector relative to the given namespace(s))
-                  that this pod should be co-located (affinity) or not
-                  co-located (anti-affinity) with, where co-located
-                  is defined as running on a node whose value of the
-                  label with key <topologyKey> matches that of any node
-                  on which a pod of the set of pods is running
-                properties:
-                  labelSelector:
-                    description: A label query over a set of resources,
-                      in this case pods.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label
-                          selector requirements. The requirements are
-                          ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: key is the label key that
-                                the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's
-                                relationship to a set of values. Valid
-                                operators are In, NotIn, Exists and
-                                DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string
-                                values. If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This
-                                array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator is
-                          "In", and the values array contains only "value".
-                          The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaceSelector:
-                    description: A label query over the set of namespaces
-                      that the term applies to. The term is applied
-                      to the union of the namespaces selected by this
-                      field and the ones listed in the namespaces field.
-                      null selector and null or empty namespaces list
-                      means "this pod's namespace". An empty selector
-                      ({}) matches all namespaces. This field is beta-level
-                      and is only honored when PodAffinityNamespaceSelector
-                      feature is enabled.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label
-                          selector requirements. The requirements are
-                          ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values, a key,
-                            and an operator that relates the key and
-                            values.
-                          properties:
-                            key:
-                              description: key is the label key that
-                                the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's
-                                relationship to a set of values. Valid
-                                operators are In, NotIn, Exists and
-                                DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string
-                                values. If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This
-                                array is replaced during a strategic
-                                merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator is
-                          "In", and the values array contains only "value".
-                          The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaces:
-                    description: namespaces specifies a static list
-                      of namespace names that the term applies to. The
-                      term is applied to the union of the namespaces
-                      listed in this field and the ones selected by
-                      namespaceSelector. null or empty namespaces list
-                      and null namespaceSelector means "this pod's namespace"
-                    items:
-                      type: string
-                    type: array
-                  topologyKey:
-                    description: This pod should be co-located (affinity)
-                      or not co-located (anti-affinity) with the pods
-                      matching the labelSelector in the specified namespaces,
-                      where co-located is defined as running on a node
-                      whose value of the label with key topologyKey
-                      matches that of any node on which any of the selected
-                      pods is running. Empty topologyKey is not allowed.
-                    type: string
-                required:
-                  - topologyKey
-                type: object
-              type: array
-          type: object
-      type: object
-    livenessProbe:
-      description: Probe describes a health check to be performed against
-        a container to determine whether it is alive or ready to receive
-        traffic.
-      properties:
-        exec:
-          description: Exec specifies the action to take.
-          properties:
-            command:
-              description: Command is the command line to execute inside
-                the container, the working directory for the command  is
-                root ('/') in the container's filesystem. The command
-                is simply exec'd, it is not run inside a shell, so traditional
-                shell instructions ('|', etc) won't work. To use a shell,
-                you need to explicitly call out to that shell. Exit
-                status of 0 is treated as live/healthy and non-zero
-                is unhealthy.
-              items:
-                type: string
-              type: array
-          type: object
-        failureThreshold:
-          description: Minimum consecutive failures for the probe to
-            be considered failed after having succeeded. Defaults to
-            3. Minimum value is 1.
-          format: int32
-          type: integer
-        grpc:
-          description: GRPC specifies an action involving a GRPC port.
-            This is an alpha field and requires enabling GRPCContainerProbe
-            feature gate.
-          properties:
-            port:
-              description: Port number of the gRPC service. Number must
-                be in the range 1 to 65535.
-              format: int32
-              type: integer
-            service:
-              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-              type: string
-          required:
-            - port
-          type: object
-        httpGet:
-          description: HTTPGet specifies the http request to perform.
-          properties:
-            host:
-              description: Host name to connect to, defaults to the
-                pod IP. You probably want to set "Host" in httpHeaders
-                instead.
-              type: string
-            httpHeaders:
-              description: Custom headers to set in the request. HTTP
-                allows repeated headers.
-              items:
-                description: HTTPHeader describes a custom header to
-                  be used in HTTP probes
-                properties:
-                  name:
-                    description: The header field name
-                    type: string
-                  value:
-                    description: The header field value
-                    type: string
-                required:
-                  - name
-                  - value
-                type: object
-              type: array
-            path:
-              description: Path to access on the HTTP server.
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Name or number of the port to access on the
-                container. Number must be in the range 1 to 65535. Name
-                must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-            scheme:
-              description: Scheme to use for connecting to the host.
-                Defaults to HTTP.
-              type: string
-          required:
-            - port
-          type: object
-        initialDelaySeconds:
-          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-        periodSeconds:
-          description: How often (in seconds) to perform the probe.
-            Default to 10 seconds. Minimum value is 1.
-          format: int32
-          type: integer
-        successThreshold:
-          description: Minimum consecutive successes for the probe to
-            be considered successful after having failed. Defaults to
-            1. Must be 1 for liveness and startup. Minimum value is
-            1.
-          format: int32
-          type: integer
-        tcpSocket:
-          description: TCPSocket specifies an action involving a TCP
-            port.
-          properties:
-            host:
-              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Number or name of the port to access on the
-                container. Number must be in the range 1 to 65535. Name
-                must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-          required:
-            - port
-          type: object
-        terminationGracePeriodSeconds:
-          description: Optional duration in seconds the pod needs to
-            terminate gracefully upon probe failure. The grace period
-            is the duration in seconds after the processes running in
-            the pod are sent a termination signal and the time when
-            the processes are forcibly halted with a kill signal. Set
-            this value longer than the expected cleanup time for your
-            process. If this value is nil, the pod's terminationGracePeriodSeconds
-            will be used. Otherwise, this value overrides the value
-            provided by the pod spec. Value must be non-negative integer.
-            The value zero indicates stop immediately via the kill signal
-            (no opportunity to shut down). This is a beta field and
-            requires enabling ProbeTerminationGracePeriod feature gate.
-            Minimum value is 1. spec.terminationGracePeriodSeconds is
-            used if unset.
-          format: int64
-          type: integer
-        timeoutSeconds:
-          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-      type: object
-    pdb:
-      description: RedisPodDisruptionBudget configure a PodDisruptionBudget
-        on the resource (leader/follower)
-      properties:
-        enabled:
-          type: boolean
-        maxUnavailable:
-          format: int32
-          type: integer
-        minAvailable:
-          format: int32
-          type: integer
-      type: object
-    readinessProbe:
-      description: Probe describes a health check to be performed against
-        a container to determine whether it is alive or ready to receive
-        traffic.
-      properties:
-        exec:
-          description: Exec specifies the action to take.
-          properties:
-            command:
-              description: Command is the command line to execute inside
-                the container, the working directory for the command  is
-                root ('/') in the container's filesystem. The command
-                is simply exec'd, it is not run inside a shell, so traditional
-                shell instructions ('|', etc) won't work. To use a shell,
-                you need to explicitly call out to that shell. Exit
-                status of 0 is treated as live/healthy and non-zero
-                is unhealthy.
-              items:
-                type: string
-              type: array
-          type: object
-        failureThreshold:
-          description: Minimum consecutive failures for the probe to
-            be considered failed after having succeeded. Defaults to
-            3. Minimum value is 1.
-          format: int32
-          type: integer
-        grpc:
-          description: GRPC specifies an action involving a GRPC port.
-            This is an alpha field and requires enabling GRPCContainerProbe
-            feature gate.
-          properties:
-            port:
-              description: Port number of the gRPC service. Number must
-                be in the range 1 to 65535.
-              format: int32
-              type: integer
-            service:
-              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-              type: string
-          required:
-            - port
-          type: object
-        httpGet:
-          description: HTTPGet specifies the http request to perform.
-          properties:
-            host:
-              description: Host name to connect to, defaults to the
-                pod IP. You probably want to set "Host" in httpHeaders
-                instead.
-              type: string
-            httpHeaders:
-              description: Custom headers to set in the request. HTTP
-                allows repeated headers.
-              items:
-                description: HTTPHeader describes a custom header to
-                  be used in HTTP probes
-                properties:
-                  name:
-                    description: The header field name
-                    type: string
-                  value:
-                    description: The header field value
-                    type: string
-                required:
-                  - name
-                  - value
-                type: object
-              type: array
-            path:
-              description: Path to access on the HTTP server.
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Name or number of the port to access on the
-                container. Number must be in the range 1 to 65535. Name
-                must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-            scheme:
-              description: Scheme to use for connecting to the host.
-                Defaults to HTTP.
-              type: string
-          required:
-            - port
-          type: object
-        initialDelaySeconds:
-          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-        periodSeconds:
-          description: How often (in seconds) to perform the probe.
-            Default to 10 seconds. Minimum value is 1.
-          format: int32
-          type: integer
-        successThreshold:
-          description: Minimum consecutive successes for the probe to
-            be considered successful after having failed. Defaults to
-            1. Must be 1 for liveness and startup. Minimum value is
-            1.
-          format: int32
-          type: integer
-        tcpSocket:
-          description: TCPSocket specifies an action involving a TCP
-            port.
-          properties:
-            host:
-              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Number or name of the port to access on the
-                container. Number must be in the range 1 to 65535. Name
-                must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-          required:
-            - port
-          type: object
-        terminationGracePeriodSeconds:
-          description: Optional duration in seconds the pod needs to
-            terminate gracefully upon probe failure. The grace period
-            is the duration in seconds after the processes running in
-            the pod are sent a termination signal and the time when
-            the processes are forcibly halted with a kill signal. Set
-            this value longer than the expected cleanup time for your
-            process. If this value is nil, the pod's terminationGracePeriodSeconds
-            will be used. Otherwise, this value overrides the value
-            provided by the pod spec. Value must be non-negative integer.
-            The value zero indicates stop immediately via the kill signal
-            (no opportunity to shut down). This is a beta field and
-            requires enabling ProbeTerminationGracePeriod feature gate.
-            Minimum value is 1. spec.terminationGracePeriodSeconds is
-            used if unset.
-          format: int64
-          type: integer
-        timeoutSeconds:
-          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-      type: object
-    redisConfig:
-      description: RedisConfig defines the external configuration of
-        Redis
-      properties:
-        additionalRedisConfig:
-          type: string
-      type: object
-    replicas:
-      format: int32
-      minimum: 3
-      type: integer
-  type: object
-resources:
-  description: ResourceRequirements describes the compute resource requirements.
-  properties:
-    limits:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-      type: object
-    requests:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-      type: object
-  type: object
-securityContext:
-  description: PodSecurityContext holds pod-level security attributes
-    and common container settings. Some fields are also present in container.securityContext.  Field
-    values of container.securityContext take precedence over field values
-    of PodSecurityContext.
-  properties:
-    fsGroup:
-      description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
-      format: int64
-      type: integer
-    fsGroupChangePolicy:
-      description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
-      type: string
-    runAsGroup:
-      description: The GID to run the entrypoint of the container process.
-        Uses runtime default if unset. May also be set in SecurityContext.  If
-        set in both SecurityContext and PodSecurityContext, the value
-        specified in SecurityContext takes precedence for that container.
-        Note that this field cannot be set when spec.os.name is windows.
-      format: int64
-      type: integer
-    runAsNonRoot:
-      description: Indicates that the container must run as a non-root
-        user. If true, the Kubelet will validate the image at runtime
-        to ensure that it does not run as UID 0 (root) and fail to start
-        the container if it does. If unset or false, no such validation
-        will be performed. May also be set in SecurityContext.  If set
-        in both SecurityContext and PodSecurityContext, the value specified
-        in SecurityContext takes precedence.
-      type: boolean
-    runAsUser:
-      description: The UID to run the entrypoint of the container process.
-        Defaults to user specified in image metadata if unspecified.
-        May also be set in SecurityContext.  If set in both SecurityContext
-        and PodSecurityContext, the value specified in SecurityContext
-        takes precedence for that container. Note that this field cannot
-        be set when spec.os.name is windows.
-      format: int64
-      type: integer
-    seLinuxOptions:
-      description: The SELinux context to be applied to all containers.
-        If unspecified, the container runtime will allocate a random
-        SELinux context for each container.  May also be set in SecurityContext.  If
-        set in both SecurityContext and PodSecurityContext, the value
-        specified in SecurityContext takes precedence for that container.
-        Note that this field cannot be set when spec.os.name is windows.
-  =======
-clusterSize:
-  format: int32
-  minimum: 3
-  type: integer
-kubernetesConfig:
-  description: KubernetesConfig will be the JSON struct for Basic
-    Redis Config
-  >>>>>>> upstream/master
-properties:
-  image:
-    type: string
-  imagePullPolicy:
-    description: PullPolicy describes a policy for if/when to
-      pull a container image
-    type: string
-  <<<<<<< HEAD
-type:
-  description: Type is a SELinux type label that applies to
-    the container.
-  type: string
-user:
-  description: User is a SELinux user label that applies to
-    the container.
-  type: string
-type: object
-seccompProfile:
-  description: The seccomp options to use by the containers in this
-    pod. Note that this field cannot be set when spec.os.name is
-    windows.
-  properties:
-    localhostProfile:
-      description: localhostProfile indicates a profile defined
-        in a file on the node should be used. The profile must be
-        preconfigured on the node to work. Must be a descending
-        path, relative to the kubelet's configured seccomp profile
-        location. Must only be set if type is "Localhost".
-      type: string
-    type:
-      description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
-      type: string
-  required:
-    - type
-  type: object
-supplementalGroups:
-  description: A list of groups applied to the first process run
-    in each container, in addition to the container's primary GID.  If
-    unspecified, no groups will be added to any container. Note
-    that this field cannot be set when spec.os.name is windows.
-  items:
-    format: int64
-    type: integer
-  type: array
-sysctls:
-  description: Sysctls hold a list of namespaced sysctls used for
-    the pod. Pods with unsupported sysctls (by the container runtime)
-    might fail to launch. Note that this field cannot be set when
-    spec.os.name is windows.
-  items:
-    description: Sysctl defines a kernel parameter to be set
-    properties:
-      name:
-        description: Name of a property to set
-        type: string
-      value:
-        description: Value of a property to set
-        type: string
-    required:
-      - name
-      - value
-    type: object
-  type: array
-windowsOptions:
-  description: The Windows specific settings applied to all containers.
-    If unspecified, the options within a container's SecurityContext
-    will be used. If set in both SecurityContext and PodSecurityContext,
-    the value specified in SecurityContext takes precedence. Note
-    that this field cannot be set when spec.os.name is linux.
-  properties:
-    gmsaCredentialSpec:
-      description: GMSACredentialSpec is where the GMSA admission
-        webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-        inlines the contents of the GMSA credential spec named by
-        the GMSACredentialSpecName field.
-      type: string
-    gmsaCredentialSpecName:
-      description: GMSACredentialSpecName is the name of the GMSA
-        credential spec to use.
-      type: string
-    hostProcess:
-      description: HostProcess determines if a container should
-        be run as a 'Host Process' container. This field is alpha-level
-        and will only be honored by components that enable the WindowsHostProcessContainers
-        feature flag. Setting this field without the feature flag
-        will result in errors when validating the Pod. All of a
-        Pod's containers must have the same effective HostProcess
-        value (it is not allowed to have a mix of HostProcess containers
-        and non-HostProcess containers).  In addition, if HostProcess
-        is true then HostNetwork must also be set to true.
-      type: boolean
-    runAsUserName:
-      description: The UserName in Windows to run the entrypoint
-        of the container process. Defaults to the user specified
-        in image metadata if unspecified. May also be set in PodSecurityContext.
-        If set in both SecurityContext and PodSecurityContext, the
-        value specified in SecurityContext takes precedence.
-      type: string
-  type: object
-type: object
-sidecars:
-  items:
-    description: Sidecar for each Redis pods
-    properties:
-      env:
-        items:
-          description: EnvVar represents an environment variable present
-            in a Container.
-  =======
-imagePullSecrets:
-  items:
-    description: LocalObjectReference contains enough information
-      to let you locate the referenced object inside the same
-      namespace.
-    properties:
-      name:
-        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-        type: string
-    type: object
-  type: array
-redisSecret:
-  description: ExistingPasswordSecret is the struct to access
-    the existing secret
-  >>>>>>> upstream/master
-properties:
-  key:
-    type: string
-  name:
-    type: string
-  <<<<<<< HEAD
-value:
-  description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
-  type: string
-valueFrom:
-  description: Source for the environment variable's value.
-    Cannot be used if value is not empty.
-  properties:
-    configMapKeyRef:
-      description: Selects a key of a ConfigMap.
-      properties:
-        key:
-          description: The key to select.
-          type: string
-        name:
-          description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-          type: string
-        optional:
-          description: Specify whether the ConfigMap or
-            its key must be defined
-          type: boolean
-      required:
-        - key
-      type: object
-    fieldRef:
-      description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
-      properties:
-        apiVersion:
-          description: Version of the schema the FieldPath
-            is written in terms of, defaults to "v1".
-          type: string
-        fieldPath:
-          description: Path of the field to select in the
-            specified API version.
-          type: string
-      required:
-        - fieldPath
-      type: object
-    resourceFieldRef:
-      description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
-      properties:
-        containerName:
-          description: 'Container name: required for volumes,
-                                      optional for env vars'
-          type: string
-        divisor:
-          anyOf:
-            - type: integer
-            - type: string
-          description: Specifies the output format of the
-            exposed resources, defaults to "1"
-          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-          x-kubernetes-int-or-string: true
-        resource:
-          description: 'Required: resource to select'
-          type: string
-      required:
-        - resource
-      type: object
-    secretKeyRef:
-      description: Selects a key of a secret in the pod's
-        namespace
-      properties:
-        key:
-          description: The key of the secret to select from.  Must
-            be a valid secret key.
-          type: string
-        name:
-          description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-          type: string
-        optional:
-          description: Specify whether the Secret or its
-            key must be defined
-          type: boolean
-      required:
-        - key
-      type: object
-  type: object
-required:
-  - name
-type: object
-type: array
-image:
-  type: string
-imagePullPolicy:
-  description: PullPolicy describes a policy for if/when to pull
-    a container image
-  type: string
-name:
-  type: string
-resources:
-  description: ResourceRequirements describes the compute resource
-    requirements.
-  properties:
-    limits:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-      type: object
-    requests:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-      type: object
-  type: object
-required:
-  - image
-  - name
-type: object
-type: array
-storage:
-  description: Storage is the inteface to add pvc and pv support in
-    redis
-  properties:
-    volumeClaimTemplate:
-      description: PersistentVolumeClaim is a user's request for and
-        claim to a persistent volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this
-                          representation of an object. Servers should convert recognized
-                          schemas to the latest internal value, and may reject unrecognized
-                          values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST
-                          resource this object represents. Servers may infer this
-                          from the endpoint the client submits requests to. Cannot
-                          be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-          type: object
-        spec:
-          description: 'Spec defines the desired characteristics of
-                          a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-          properties:
-            accessModes:
-              description: 'AccessModes contains the desired access
-                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-              items:
-                type: string
-              type: array
-            dataSource:
-              description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                              * An existing PVC (PersistentVolumeClaim) If the provisioner
-                              or an external controller can support the specified
-                              data source, it will create a new volume based on the
-                              contents of the specified data source. If the AnyVolumeDataSource
-                              feature gate is enabled, this field will always have
-                              the same contents as the DataSourceRef field.'
-              properties:
-                apiGroup:
-                  description: APIGroup is the group for the resource
-                    being referenced. If APIGroup is not specified,
-                    the specified Kind must be in the core API group.
-                    For any other third-party types, APIGroup is required.
-                  type: string
-                kind:
-                  description: Kind is the type of resource being referenced
-                  type: string
-                name:
-                  description: Name is the name of resource being referenced
-                  type: string
-              required:
-                - kind
-                - name
-              type: object
-            dataSourceRef:
-              description: 'Specifies the object from which to populate
-                              the volume with data, if a non-empty volume is desired.
-                              This may be any local object from a non-empty API group
-                              (non core object) or a PersistentVolumeClaim object.
-                              When this field is specified, volume binding will only
-                              succeed if the type of the specified object matches
-                              some installed volume populator or dynamic provisioner.
-                              This field will replace the functionality of the DataSource
-                              field and as such if both fields are non-empty, they
-                              must have the same value. For backwards compatibility,
-                              both fields (DataSource and DataSourceRef) will be set
-                              to the same value automatically if one of them is empty
-                              and the other is non-empty. There are two important
-                              differences between DataSource and DataSourceRef: *
-                              While DataSource only allows two specific types of objects,
-                              DataSourceRef   allows any non-core object, as well
-                              as PersistentVolumeClaim objects. * While DataSource
-                              ignores disallowed values (dropping them), DataSourceRef   preserves
-                              all values, and generates an error if a disallowed value
-                              is   specified. (Alpha) Using this field requires the
-                              AnyVolumeDataSource feature gate to be enabled.'
-              properties:
-                apiGroup:
-                  description: APIGroup is the group for the resource
-                    being referenced. If APIGroup is not specified,
-                    the specified Kind must be in the core API group.
-                    For any other third-party types, APIGroup is required.
-                  type: string
-                kind:
-                  description: Kind is the type of resource being referenced
-                  type: string
-                name:
-                  description: Name is the name of resource being referenced
-                  type: string
-              required:
-                - kind
-                - name
-              type: object
-            resources:
-              description: 'Resources represents the minimum resources
-                              the volume should have. If RecoverVolumeExpansionFailure
-                              feature is enabled users are allowed to specify resource
-                              requirements that are lower than previous value but
-                              must still be higher than capacity recorded in the status
-                              field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
                                   of compute resources required. If Requests is omitted
                                   for a container, it defaults to Limits if that is
                                   explicitly specified, otherwise to an implementation-defined
                                   value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                  type: object
-              type: object
-            selector:
-              description: A label query over volumes to consider for
-                binding.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector
-                    requirements. The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector
-                      that contains values, a key, and an operator that
-                      relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector
-                          applies to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship
-                          to a set of values. Valid operators are In,
-                          NotIn, Exists and DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values.
-                          If the operator is In or NotIn, the values
-                          array must be non-empty. If the operator is
-                          Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a
-                          strategic merge patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                      - key
-                      - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs.
-                    A single {key,value} in the matchLabels map is equivalent
-                    to an element of matchExpressions, whose key field
-                    is "key", the operator is "In", and the values array
-                    contains only "value". The requirements are ANDed.
-                  type: object
-              type: object
-            storageClassName:
-              description: 'Name of the StorageClass required by the
+                                type: object
+                            type: object
+                          selector:
+                            description: A label query over volumes to consider for
+                              binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          storageClassName:
+                            description: 'Name of the StorageClass required by the
                               claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-              type: string
-            volumeMode:
-              description: volumeMode defines what type of volume is
-                required by the claim. Value of Filesystem is implied
-                when not included in claim spec.
-              type: string
-            volumeName:
-              description: VolumeName is the binding reference to the
-                PersistentVolume backing this claim.
-              type: string
-          type: object
-        status:
-          description: 'Status represents the current information/status
+                            type: string
+                          volumeMode:
+                            description: volumeMode defines what type of volume is
+                              required by the claim. Value of Filesystem is implied
+                              when not included in claim spec.
+                            type: string
+                          volumeName:
+                            description: VolumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                      status:
+                        description: 'Status represents the current information/status
                           of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-          properties:
-            accessModes:
-              description: 'AccessModes contains the actual access modes
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the actual access modes
                               the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-              items:
-                type: string
-              type: array
-            allocatedResources:
-              additionalProperties:
-                anyOf:
-                  - type: integer
-                  - type: string
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              description: The storage resource within AllocatedResources
-                tracks the capacity allocated to a PVC. It may be larger
-                than the actual capacity when a volume expansion operation
-                is requested. For storage quota, the larger value from
-                allocatedResources and PVC.spec.resources is used. If
-                allocatedResources is not set, PVC.spec.resources alone
-                is used for quota calculation. If a volume expansion
-                capacity request is lowered, allocatedResources is only
-                lowered if there are no expansion operations in progress
-                and if the actual volume capacity is equal or lower
-                than the requested capacity. This is an alpha field
-                and requires enabling RecoverVolumeExpansionFailure
-                feature.
-              type: object
-            capacity:
-  =======
-type: object
-resources:
-  description: ResourceRequirements describes the compute resource
-    requirements.
-  properties:
-    limits:
-  >>>>>>> upstream/master
-  additionalProperties:
-    anyOf:
-    - type: integer
-    - type: string
-    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-    x-kubernetes-int-or-string: true
-  description: 'Limits describes the maximum amount of compute
-    resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-  type: object
-requests:
-  additionalProperties:
-    anyOf:
-      - type: integer
-      - type: string
-    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-    x-kubernetes-int-or-string: true
-  description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-  type: object
-type: object
-required:
-  - image
-type: object
-nodeSelector:
-  additionalProperties:
-    type: string
-  type: object
-priorityClassName:
-  type: string
-redisExporter:
-  description: RedisExporter interface will have the information
-    for redis exporter related stuff
-  properties:
-    enabled:
-      type: boolean
-    env:
-      items:
-        description: EnvVar represents an environment variable present
-          in a Container.
-        properties:
-          name:
-            description: Name of the environment variable. Must
-              be a C_IDENTIFIER.
-            type: string
-          value:
-            description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-            type: string
-          valueFrom:
-            description: Source for the environment variable's value.
-              Cannot be used if value is not empty.
-            properties:
-              configMapKeyRef:
-                description: Selects a key of a ConfigMap.
-                properties:
-                  key:
-                    description: The key to select.
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                    type: string
-                  optional:
-                    description: Specify whether the ConfigMap or
-                      its key must be defined
-                    type: boolean
-                required:
-                  - key
+                            items:
+                              type: string
+                            type: array
+                          allocatedResources:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: The storage resource within AllocatedResources
+                              tracks the capacity allocated to a PVC. It may be larger
+                              than the actual capacity when a volume expansion operation
+                              is requested. For storage quota, the larger value from
+                              allocatedResources and PVC.spec.resources is used. If
+                              allocatedResources is not set, PVC.spec.resources alone
+                              is used for quota calculation. If a volume expansion
+                              capacity request is lowered, allocatedResources is only
+                              lowered if there are no expansion operations in progress
+                              and if the actual volume capacity is equal or lower
+                              than the requested capacity. This is an alpha field
+                              and requires enabling RecoverVolumeExpansionFailure
+                              feature.
+                            type: object
+                          capacity:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: Represents the actual resources of the underlying
+                              volume.
+                            type: object
+                          conditions:
+                            description: Current Condition of persistent volume claim.
+                              If underlying persistent volume is being resized then
+                              the Condition will be set to 'ResizeStarted'.
+                            items:
+                              description: PersistentVolumeClaimCondition contails
+                                details about state of pvc
+                              properties:
+                                lastProbeTime:
+                                  description: Last time we probed the condition.
+                                  format: date-time
+                                  type: string
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned
+                                    from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details
+                                    about last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, this should be a short, machine
+                                    understandable string that gives the reason for
+                                    condition's last transition. If it reports "ResizeStarted"
+                                    that means the underlying persistent volume is
+                                    being resized.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: PersistentVolumeClaimConditionType
+                                    is a valid value of PersistentVolumeClaimCondition.Type
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          phase:
+                            description: Phase represents the current phase of PersistentVolumeClaim.
+                            type: string
+                          resizeStatus:
+                            description: ResizeStatus stores status of resize operation.
+                              ResizeStatus is not set by default but when expansion
+                              is complete resizeStatus is set to empty string by resize
+                              controller or kubelet. This is an alpha field and requires
+                              enabling RecoverVolumeExpansionFailure feature.
+                            type: string
+                        type: object
+                    type: object
                 type: object
-              fieldRef:
-                description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                properties:
-                  apiVersion:
-                    description: Version of the schema the FieldPath
-                      is written in terms of, defaults to "v1".
-                    type: string
-                  fieldPath:
-                    description: Path of the field to select in
-                      the specified API version.
-                    type: string
-                required:
-                  - fieldPath
-                type: object
-              resourceFieldRef:
-                description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                properties:
-                  containerName:
-                    description: 'Container name: required for volumes,
-                                        optional for env vars'
-                    type: string
-                  divisor:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    description: Specifies the output format of
-                      the exposed resources, defaults to "1"
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  resource:
-                    description: 'Required: resource to select'
-                    type: string
-                required:
-                  - resource
-                type: object
-              secretKeyRef:
-                description: Selects a key of a secret in the pod's
-                  namespace
-                properties:
-                  key:
-                    description: The key of the secret to select
-                      from.  Must be a valid secret key.
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                    type: string
-                  optional:
-                    description: Specify whether the Secret or its
-                      key must be defined
-                    type: boolean
-                required:
-                  - key
-                type: object
+              tolerations:
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - clusterSize
+            - kubernetesConfig
+            type: object
+          status:
+            description: RedisClusterStatus defines the observed state of RedisCluster
             type: object
         required:
-          - name
+        - spec
         type: object
-      type: array
-    image:
-      type: string
-    imagePullPolicy:
-      description: PullPolicy describes a policy for if/when to
-        pull a container image
-      type: string
-    resources:
-      description: ResourceRequirements describes the compute resource
-        requirements.
-      properties:
-        limits:
-          additionalProperties:
-            anyOf:
-              - type: integer
-              - type: string
-            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-            x-kubernetes-int-or-string: true
-          description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-          type: object
-        requests:
-          additionalProperties:
-            anyOf:
-              - type: integer
-              - type: string
-            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-            x-kubernetes-int-or-string: true
-          description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-          type: object
-      type: object
-  required:
-    - image
-  type: object
-redisFollower:
-  description: RedisFollower interface will have the redis follower
-    configuration
-  properties:
-    affinity:
-      description: Affinity is a group of affinity scheduling rules.
-      properties:
-        nodeAffinity:
-          description: Describes node affinity scheduling rules
-            for the pod.
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule
-                pods to nodes that satisfy the affinity expressions
-                specified by this field, but it may choose a node
-                that violates one or more of the expressions. The
-                node that is most preferred is the one with the
-                greatest sum of weights, i.e. for each node that
-                meets all of the scheduling requirements (resource
-                request, requiredDuringScheduling affinity expressions,
-                etc.), compute a sum by iterating through the elements
-                of this field and adding "weight" to the sum if
-                the node matches the corresponding matchExpressions;
-                the node(s) with the highest sum are the most preferred.
-              items:
-                description: An empty preferred scheduling term
-                  matches all objects with implicit weight 0 (i.e.
-                  it's a no-op). A null preferred scheduling term
-                  matches no objects (i.e. is also a no-op).
-                properties:
-                  preference:
-                    description: A node selector term, associated
-                      with the corresponding weight.
-                    properties:
-                      matchExpressions:
-                        description: A list of node selector requirements
-                          by node's labels.
-                        items:
-                          description: A node selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: The label key that the
-                                selector applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty.
-                                If the operator is Gt or Lt, the
-                                values array must have a single
-                                element, which will be interpreted
-                                as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements
-                          by node's fields.
-                        items:
-                          description: A node selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: The label key that the
-                                selector applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty.
-                                If the operator is Gt or Lt, the
-                                values array must have a single
-                                element, which will be interpreted
-                                as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                    type: object
-                  weight:
-                    description: Weight associated with matching
-                      the corresponding nodeSelectorTerm, in the
-                      range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - preference
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the affinity requirements specified
-                by this field are not met at scheduling time, the
-                pod will not be scheduled onto the node. If the
-                affinity requirements specified by this field cease
-                to be met at some point during pod execution (e.g.
-                due to an update), the system may or may not try
-                to eventually evict the pod from its node.
-              properties:
-                nodeSelectorTerms:
-                  description: Required. A list of node selector
-                    terms. The terms are ORed.
-                  items:
-                    description: A null or empty node selector term
-                      matches no objects. The requirements of them
-                      are ANDed. The TopologySelectorTerm type implements
-                      a subset of the NodeSelectorTerm.
-                    properties:
-                      matchExpressions:
-                        description: A list of node selector requirements
-                          by node's labels.
-                        items:
-                          description: A node selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: The label key that the
-                                selector applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty.
-                                If the operator is Gt or Lt, the
-                                values array must have a single
-                                element, which will be interpreted
-                                as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements
-                          by node's fields.
-                        items:
-                          description: A node selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: The label key that the
-                                selector applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty.
-                                If the operator is Gt or Lt, the
-                                values array must have a single
-                                element, which will be interpreted
-                                as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                    type: object
-                  type: array
-              required:
-                - nodeSelectorTerms
-              type: object
-          type: object
-        podAffinity:
-          description: Describes pod affinity scheduling rules (e.g.
-            co-locate this pod in the same node, zone, etc. as some
-            other pod(s)).
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule
-                pods to nodes that satisfy the affinity expressions
-                specified by this field, but it may choose a node
-                that violates one or more of the expressions. The
-                node that is most preferred is the one with the
-                greatest sum of weights, i.e. for each node that
-                meets all of the scheduling requirements (resource
-                request, requiredDuringScheduling affinity expressions,
-                etc.), compute a sum by iterating through the elements
-                of this field and adding "weight" to the sum if
-                the node has pods which matches the corresponding
-                podAffinityTerm; the node(s) with the highest sum
-                are the most preferred.
-              items:
-                description: The weights of all of the matched WeightedPodAffinityTerm
-                  fields are added per-node to find the most preferred
-                  node(s)
-                properties:
-                  podAffinityTerm:
-                    description: Required. A pod affinity term,
-                      associated with the corresponding weight.
-                    properties:
-                      labelSelector:
-                        description: A label query over a set of
-                          resources, in this case pods.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The
-                              requirements are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label
-                                    key that the selector applies
-                                    to.
-                                  type: string
-                                operator:
-                                  description: operator represents
-                                    a key's relationship to a set
-                                    of values. Valid operators are
-                                    In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array
-                                    of string values. If the operator
-                                    is In or NotIn, the values array
-                                    must be non-empty. If the operator
-                                    is Exists or DoesNotExist, the
-                                    values array must be empty.
-                                    This array is replaced during
-                                    a strategic merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of
-                              {key,value} pairs. A single {key,value}
-                              in the matchLabels map is equivalent
-                              to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are
-                              ANDed.
-                            type: object
-                        type: object
-                      namespaces:
-                        description: namespaces specifies which
-                          namespaces the labelSelector applies to
-                          (matches against); null or empty list
-                          means "this pod's namespace"
-                        items:
-                          type: string
-                        type: array
-                      topologyKey:
-                        description: This pod should be co-located
-                          (affinity) or not co-located (anti-affinity)
-                          with the pods matching the labelSelector
-                          in the specified namespaces, where co-located
-                          is defined as running on a node whose
-                          value of the label with key topologyKey
-                          matches that of any node on which any
-                          of the selected pods is running. Empty
-                          topologyKey is not allowed.
-                        type: string
-                    required:
-                      - topologyKey
-                    type: object
-                  weight:
-                    description: weight associated with matching
-                      the corresponding podAffinityTerm, in the
-                      range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - podAffinityTerm
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the affinity requirements specified
-                by this field are not met at scheduling time, the
-                pod will not be scheduled onto the node. If the
-                affinity requirements specified by this field cease
-                to be met at some point during pod execution (e.g.
-                due to a pod label update), the system may or may
-                not try to eventually evict the pod from its node.
-                When there are multiple elements, the lists of nodes
-                corresponding to each podAffinityTerm are intersected,
-                i.e. all terms must be satisfied.
-              items:
-                description: Defines a set of pods (namely those
-                  matching the labelSelector relative to the given
-                  namespace(s)) that this pod should be co-located
-                  (affinity) or not co-located (anti-affinity) with,
-                  where co-located is defined as running on a node
-                  whose value of the label with key <topologyKey>
-                  matches that of any node on which a pod of the
-                  set of pods is running
-                properties:
-                  labelSelector:
-                    description: A label query over a set of resources,
-                      in this case pods.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list
-                          of label selector requirements. The requirements
-                          are ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key
-                                that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a
-                                key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists
-                                and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of
-                                string values. If the operator is
-                                In or NotIn, the values array must
-                                be non-empty. If the operator is
-                                Exists or DoesNotExist, the values
-                                array must be empty. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator
-                          is "In", and the values array contains
-                          only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaces:
-                    description: namespaces specifies which namespaces
-                      the labelSelector applies to (matches against);
-                      null or empty list means "this pod's namespace"
-                    items:
-                      type: string
-                    type: array
-                  topologyKey:
-                    description: This pod should be co-located (affinity)
-                      or not co-located (anti-affinity) with the
-                      pods matching the labelSelector in the specified
-                      namespaces, where co-located is defined as
-                      running on a node whose value of the label
-                      with key topologyKey matches that of any node
-                      on which any of the selected pods is running.
-                      Empty topologyKey is not allowed.
-                    type: string
-                required:
-                  - topologyKey
-                type: object
-              type: array
-          type: object
-        podAntiAffinity:
-          description: Describes pod anti-affinity scheduling rules
-            (e.g. avoid putting this pod in the same node, zone,
-            etc. as some other pod(s)).
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule
-                pods to nodes that satisfy the anti-affinity expressions
-                specified by this field, but it may choose a node
-                that violates one or more of the expressions. The
-                node that is most preferred is the one with the
-                greatest sum of weights, i.e. for each node that
-                meets all of the scheduling requirements (resource
-                request, requiredDuringScheduling anti-affinity
-                expressions, etc.), compute a sum by iterating through
-                the elements of this field and adding "weight" to
-                the sum if the node has pods which matches the corresponding
-                podAffinityTerm; the node(s) with the highest sum
-                are the most preferred.
-              items:
-                description: The weights of all of the matched WeightedPodAffinityTerm
-                  fields are added per-node to find the most preferred
-                  node(s)
-                properties:
-                  podAffinityTerm:
-                    description: Required. A pod affinity term,
-                      associated with the corresponding weight.
-                    properties:
-                      labelSelector:
-                        description: A label query over a set of
-                          resources, in this case pods.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The
-                              requirements are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label
-                                    key that the selector applies
-                                    to.
-                                  type: string
-                                operator:
-                                  description: operator represents
-                                    a key's relationship to a set
-                                    of values. Valid operators are
-                                    In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array
-                                    of string values. If the operator
-                                    is In or NotIn, the values array
-                                    must be non-empty. If the operator
-                                    is Exists or DoesNotExist, the
-                                    values array must be empty.
-                                    This array is replaced during
-                                    a strategic merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of
-                              {key,value} pairs. A single {key,value}
-                              in the matchLabels map is equivalent
-                              to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are
-                              ANDed.
-                            type: object
-                        type: object
-                      namespaces:
-                        description: namespaces specifies which
-                          namespaces the labelSelector applies to
-                          (matches against); null or empty list
-                          means "this pod's namespace"
-                        items:
-                          type: string
-                        type: array
-                      topologyKey:
-                        description: This pod should be co-located
-                          (affinity) or not co-located (anti-affinity)
-                          with the pods matching the labelSelector
-                          in the specified namespaces, where co-located
-                          is defined as running on a node whose
-                          value of the label with key topologyKey
-                          matches that of any node on which any
-                          of the selected pods is running. Empty
-                          topologyKey is not allowed.
-                        type: string
-                    required:
-                      - topologyKey
-                    type: object
-                  weight:
-                    description: weight associated with matching
-                      the corresponding podAffinityTerm, in the
-                      range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - podAffinityTerm
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the anti-affinity requirements specified
-                by this field are not met at scheduling time, the
-                pod will not be scheduled onto the node. If the
-                anti-affinity requirements specified by this field
-                cease to be met at some point during pod execution
-                (e.g. due to a pod label update), the system may
-                or may not try to eventually evict the pod from
-                its node. When there are multiple elements, the
-                lists of nodes corresponding to each podAffinityTerm
-                are intersected, i.e. all terms must be satisfied.
-              items:
-                description: Defines a set of pods (namely those
-                  matching the labelSelector relative to the given
-                  namespace(s)) that this pod should be co-located
-                  (affinity) or not co-located (anti-affinity) with,
-                  where co-located is defined as running on a node
-                  whose value of the label with key <topologyKey>
-                  matches that of any node on which a pod of the
-                  set of pods is running
-                properties:
-                  labelSelector:
-                    description: A label query over a set of resources,
-                      in this case pods.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list
-                          of label selector requirements. The requirements
-                          are ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key
-                                that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a
-                                key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists
-                                and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of
-                                string values. If the operator is
-                                In or NotIn, the values array must
-                                be non-empty. If the operator is
-                                Exists or DoesNotExist, the values
-                                array must be empty. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator
-                          is "In", and the values array contains
-                          only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaces:
-                    description: namespaces specifies which namespaces
-                      the labelSelector applies to (matches against);
-                      null or empty list means "this pod's namespace"
-                    items:
-                      type: string
-                    type: array
-                  topologyKey:
-                    description: This pod should be co-located (affinity)
-                      or not co-located (anti-affinity) with the
-                      pods matching the labelSelector in the specified
-                      namespaces, where co-located is defined as
-                      running on a node whose value of the label
-                      with key topologyKey matches that of any node
-                      on which any of the selected pods is running.
-                      Empty topologyKey is not allowed.
-                    type: string
-                required:
-                  - topologyKey
-                type: object
-              type: array
-          type: object
-      type: object
-    livenessProbe:
-      description: Probe describes a health check to be performed
-        against a container to determine whether it is alive or
-        ready to receive traffic.
-      properties:
-        exec:
-          description: One and only one of the following should
-            be specified. Exec specifies the action to take.
-          properties:
-            command:
-              description: Command is the command line to execute
-                inside the container, the working directory for
-                the command  is root ('/') in the container's filesystem.
-                The command is simply exec'd, it is not run inside
-                a shell, so traditional shell instructions ('|',
-                etc) won't work. To use a shell, you need to explicitly
-                call out to that shell. Exit status of 0 is treated
-                as live/healthy and non-zero is unhealthy.
-              items:
-                type: string
-              type: array
-          type: object
-        failureThreshold:
-          description: Minimum consecutive failures for the probe
-            to be considered failed after having succeeded. Defaults
-            to 3. Minimum value is 1.
-          format: int32
-          type: integer
-        httpGet:
-          description: HTTPGet specifies the http request to perform.
-          properties:
-            host:
-              description: Host name to connect to, defaults to
-                the pod IP. You probably want to set "Host" in httpHeaders
-                instead.
-              type: string
-            httpHeaders:
-              description: Custom headers to set in the request.
-                HTTP allows repeated headers.
-              items:
-                description: HTTPHeader describes a custom header
-                  to be used in HTTP probes
-                properties:
-                  name:
-                    description: The header field name
-                    type: string
-                  value:
-                    description: The header field value
-                    type: string
-                required:
-                  - name
-                  - value
-                type: object
-              type: array
-            path:
-              description: Path to access on the HTTP server.
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Name or number of the port to access
-                on the container. Number must be in the range 1
-                to 65535. Name must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-            scheme:
-              description: Scheme to use for connecting to the host.
-                Defaults to HTTP.
-              type: string
-          required:
-            - port
-          type: object
-        initialDelaySeconds:
-          description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-        periodSeconds:
-          description: How often (in seconds) to perform the probe.
-            Default to 10 seconds. Minimum value is 1.
-          format: int32
-          type: integer
-        successThreshold:
-          description: Minimum consecutive successes for the probe
-            to be considered successful after having failed. Defaults
-            to 1. Must be 1 for liveness and startup. Minimum value
-            is 1.
-          format: int32
-          type: integer
-        tcpSocket:
-          description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-          properties:
-            host:
-              description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Number or name of the port to access
-                on the container. Number must be in the range 1
-                to 65535. Name must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-          required:
-            - port
-          type: object
-        timeoutSeconds:
-          description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-      type: object
-    pdb:
-      description: RedisPodDisruptionBudget configure a PodDisruptionBudget
-        on the resource (leader/follower)
-      properties:
-        enabled:
-          type: boolean
-        maxUnavailable:
-          format: int32
-          type: integer
-        minAvailable:
-          format: int32
-          type: integer
-      type: object
-    readinessProbe:
-      description: Probe describes a health check to be performed
-        against a container to determine whether it is alive or
-        ready to receive traffic.
-      properties:
-        exec:
-          description: One and only one of the following should
-            be specified. Exec specifies the action to take.
-          properties:
-            command:
-              description: Command is the command line to execute
-                inside the container, the working directory for
-                the command  is root ('/') in the container's filesystem.
-                The command is simply exec'd, it is not run inside
-                a shell, so traditional shell instructions ('|',
-                etc) won't work. To use a shell, you need to explicitly
-                call out to that shell. Exit status of 0 is treated
-                as live/healthy and non-zero is unhealthy.
-              items:
-                type: string
-              type: array
-          type: object
-        failureThreshold:
-          description: Minimum consecutive failures for the probe
-            to be considered failed after having succeeded. Defaults
-            to 3. Minimum value is 1.
-          format: int32
-          type: integer
-        httpGet:
-          description: HTTPGet specifies the http request to perform.
-          properties:
-            host:
-              description: Host name to connect to, defaults to
-                the pod IP. You probably want to set "Host" in httpHeaders
-                instead.
-              type: string
-            httpHeaders:
-              description: Custom headers to set in the request.
-                HTTP allows repeated headers.
-              items:
-                description: HTTPHeader describes a custom header
-                  to be used in HTTP probes
-                properties:
-                  name:
-                    description: The header field name
-                    type: string
-                  value:
-                    description: The header field value
-                    type: string
-                required:
-                  - name
-                  - value
-                type: object
-              type: array
-            path:
-              description: Path to access on the HTTP server.
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Name or number of the port to access
-                on the container. Number must be in the range 1
-                to 65535. Name must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-            scheme:
-              description: Scheme to use for connecting to the host.
-                Defaults to HTTP.
-              type: string
-          required:
-            - port
-          type: object
-        initialDelaySeconds:
-          description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-        periodSeconds:
-          description: How often (in seconds) to perform the probe.
-            Default to 10 seconds. Minimum value is 1.
-          format: int32
-          type: integer
-        successThreshold:
-          description: Minimum consecutive successes for the probe
-            to be considered successful after having failed. Defaults
-            to 1. Must be 1 for liveness and startup. Minimum value
-            is 1.
-          format: int32
-          type: integer
-        tcpSocket:
-          description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-          properties:
-            host:
-              description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Number or name of the port to access
-                on the container. Number must be in the range 1
-                to 65535. Name must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-          required:
-            - port
-          type: object
-        timeoutSeconds:
-          description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-      type: object
-    redisConfig:
-      description: RedisConfig defines the external configuration
-        of Redis
-      properties:
-        additionalRedisConfig:
-          type: string
-      type: object
-    replicas:
-      format: int32
-      type: integer
-  type: object
-redisLeader:
-  description: RedisLeader interface will have the redis leader
-    configuration
-  properties:
-    affinity:
-      description: Affinity is a group of affinity scheduling rules.
-      properties:
-        nodeAffinity:
-          description: Describes node affinity scheduling rules
-            for the pod.
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule
-                pods to nodes that satisfy the affinity expressions
-                specified by this field, but it may choose a node
-                that violates one or more of the expressions. The
-                node that is most preferred is the one with the
-                greatest sum of weights, i.e. for each node that
-                meets all of the scheduling requirements (resource
-                request, requiredDuringScheduling affinity expressions,
-                etc.), compute a sum by iterating through the elements
-                of this field and adding "weight" to the sum if
-                the node matches the corresponding matchExpressions;
-                the node(s) with the highest sum are the most preferred.
-              items:
-                description: An empty preferred scheduling term
-                  matches all objects with implicit weight 0 (i.e.
-                  it's a no-op). A null preferred scheduling term
-                  matches no objects (i.e. is also a no-op).
-                properties:
-                  preference:
-                    description: A node selector term, associated
-                      with the corresponding weight.
-                    properties:
-                      matchExpressions:
-                        description: A list of node selector requirements
-                          by node's labels.
-                        items:
-                          description: A node selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: The label key that the
-                                selector applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty.
-                                If the operator is Gt or Lt, the
-                                values array must have a single
-                                element, which will be interpreted
-                                as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements
-                          by node's fields.
-                        items:
-                          description: A node selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: The label key that the
-                                selector applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty.
-                                If the operator is Gt or Lt, the
-                                values array must have a single
-                                element, which will be interpreted
-                                as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                    type: object
-                  weight:
-                    description: Weight associated with matching
-                      the corresponding nodeSelectorTerm, in the
-                      range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - preference
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the affinity requirements specified
-                by this field are not met at scheduling time, the
-                pod will not be scheduled onto the node. If the
-                affinity requirements specified by this field cease
-                to be met at some point during pod execution (e.g.
-                due to an update), the system may or may not try
-                to eventually evict the pod from its node.
-              properties:
-                nodeSelectorTerms:
-                  description: Required. A list of node selector
-                    terms. The terms are ORed.
-                  items:
-                    description: A null or empty node selector term
-                      matches no objects. The requirements of them
-                      are ANDed. The TopologySelectorTerm type implements
-                      a subset of the NodeSelectorTerm.
-                    properties:
-                      matchExpressions:
-                        description: A list of node selector requirements
-                          by node's labels.
-                        items:
-                          description: A node selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: The label key that the
-                                selector applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty.
-                                If the operator is Gt or Lt, the
-                                values array must have a single
-                                element, which will be interpreted
-                                as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements
-                          by node's fields.
-                        items:
-                          description: A node selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: The label key that the
-                                selector applies to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship
-                                to a set of values. Valid operators
-                                are In, NotIn, Exists, DoesNotExist.
-                                Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values.
-                                If the operator is In or NotIn,
-                                the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist,
-                                the values array must be empty.
-                                If the operator is Gt or Lt, the
-                                values array must have a single
-                                element, which will be interpreted
-                                as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                    type: object
-                  type: array
-              required:
-                - nodeSelectorTerms
-              type: object
-          type: object
-        podAffinity:
-          description: Describes pod affinity scheduling rules (e.g.
-            co-locate this pod in the same node, zone, etc. as some
-            other pod(s)).
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule
-                pods to nodes that satisfy the affinity expressions
-                specified by this field, but it may choose a node
-                that violates one or more of the expressions. The
-                node that is most preferred is the one with the
-                greatest sum of weights, i.e. for each node that
-                meets all of the scheduling requirements (resource
-                request, requiredDuringScheduling affinity expressions,
-                etc.), compute a sum by iterating through the elements
-                of this field and adding "weight" to the sum if
-                the node has pods which matches the corresponding
-                podAffinityTerm; the node(s) with the highest sum
-                are the most preferred.
-              items:
-                description: The weights of all of the matched WeightedPodAffinityTerm
-                  fields are added per-node to find the most preferred
-                  node(s)
-                properties:
-                  podAffinityTerm:
-                    description: Required. A pod affinity term,
-                      associated with the corresponding weight.
-                    properties:
-                      labelSelector:
-                        description: A label query over a set of
-                          resources, in this case pods.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The
-                              requirements are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label
-                                    key that the selector applies
-                                    to.
-                                  type: string
-                                operator:
-                                  description: operator represents
-                                    a key's relationship to a set
-                                    of values. Valid operators are
-                                    In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array
-                                    of string values. If the operator
-                                    is In or NotIn, the values array
-                                    must be non-empty. If the operator
-                                    is Exists or DoesNotExist, the
-                                    values array must be empty.
-                                    This array is replaced during
-                                    a strategic merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of
-                              {key,value} pairs. A single {key,value}
-                              in the matchLabels map is equivalent
-                              to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are
-                              ANDed.
-                            type: object
-                        type: object
-                      namespaces:
-                        description: namespaces specifies which
-                          namespaces the labelSelector applies to
-                          (matches against); null or empty list
-                          means "this pod's namespace"
-                        items:
-                          type: string
-                        type: array
-                      topologyKey:
-                        description: This pod should be co-located
-                          (affinity) or not co-located (anti-affinity)
-                          with the pods matching the labelSelector
-                          in the specified namespaces, where co-located
-                          is defined as running on a node whose
-                          value of the label with key topologyKey
-                          matches that of any node on which any
-                          of the selected pods is running. Empty
-                          topologyKey is not allowed.
-                        type: string
-                    required:
-                      - topologyKey
-                    type: object
-                  weight:
-                    description: weight associated with matching
-                      the corresponding podAffinityTerm, in the
-                      range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - podAffinityTerm
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the affinity requirements specified
-                by this field are not met at scheduling time, the
-                pod will not be scheduled onto the node. If the
-                affinity requirements specified by this field cease
-                to be met at some point during pod execution (e.g.
-                due to a pod label update), the system may or may
-                not try to eventually evict the pod from its node.
-                When there are multiple elements, the lists of nodes
-                corresponding to each podAffinityTerm are intersected,
-                i.e. all terms must be satisfied.
-              items:
-                description: Defines a set of pods (namely those
-                  matching the labelSelector relative to the given
-                  namespace(s)) that this pod should be co-located
-                  (affinity) or not co-located (anti-affinity) with,
-                  where co-located is defined as running on a node
-                  whose value of the label with key <topologyKey>
-                  matches that of any node on which a pod of the
-                  set of pods is running
-                properties:
-                  labelSelector:
-                    description: A label query over a set of resources,
-                      in this case pods.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list
-                          of label selector requirements. The requirements
-                          are ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key
-                                that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a
-                                key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists
-                                and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of
-                                string values. If the operator is
-                                In or NotIn, the values array must
-                                be non-empty. If the operator is
-                                Exists or DoesNotExist, the values
-                                array must be empty. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator
-                          is "In", and the values array contains
-                          only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaces:
-                    description: namespaces specifies which namespaces
-                      the labelSelector applies to (matches against);
-                      null or empty list means "this pod's namespace"
-                    items:
-                      type: string
-                    type: array
-                  topologyKey:
-                    description: This pod should be co-located (affinity)
-                      or not co-located (anti-affinity) with the
-                      pods matching the labelSelector in the specified
-                      namespaces, where co-located is defined as
-                      running on a node whose value of the label
-                      with key topologyKey matches that of any node
-                      on which any of the selected pods is running.
-                      Empty topologyKey is not allowed.
-                    type: string
-                required:
-                  - topologyKey
-                type: object
-              type: array
-          type: object
-        podAntiAffinity:
-          description: Describes pod anti-affinity scheduling rules
-            (e.g. avoid putting this pod in the same node, zone,
-            etc. as some other pod(s)).
-          properties:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              description: The scheduler will prefer to schedule
-                pods to nodes that satisfy the anti-affinity expressions
-                specified by this field, but it may choose a node
-                that violates one or more of the expressions. The
-                node that is most preferred is the one with the
-                greatest sum of weights, i.e. for each node that
-                meets all of the scheduling requirements (resource
-                request, requiredDuringScheduling anti-affinity
-                expressions, etc.), compute a sum by iterating through
-                the elements of this field and adding "weight" to
-                the sum if the node has pods which matches the corresponding
-                podAffinityTerm; the node(s) with the highest sum
-                are the most preferred.
-              items:
-                description: The weights of all of the matched WeightedPodAffinityTerm
-                  fields are added per-node to find the most preferred
-                  node(s)
-                properties:
-                  podAffinityTerm:
-                    description: Required. A pod affinity term,
-                      associated with the corresponding weight.
-                    properties:
-                      labelSelector:
-                        description: A label query over a set of
-                          resources, in this case pods.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list
-                              of label selector requirements. The
-                              requirements are ANDed.
-                            items:
-                              description: A label selector requirement
-                                is a selector that contains values,
-                                a key, and an operator that relates
-                                the key and values.
-                              properties:
-                                key:
-                                  description: key is the label
-                                    key that the selector applies
-                                    to.
-                                  type: string
-                                operator:
-                                  description: operator represents
-                                    a key's relationship to a set
-                                    of values. Valid operators are
-                                    In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array
-                                    of string values. If the operator
-                                    is In or NotIn, the values array
-                                    must be non-empty. If the operator
-                                    is Exists or DoesNotExist, the
-                                    values array must be empty.
-                                    This array is replaced during
-                                    a strategic merge patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                                - key
-                                - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of
-                              {key,value} pairs. A single {key,value}
-                              in the matchLabels map is equivalent
-                              to an element of matchExpressions,
-                              whose key field is "key", the operator
-                              is "In", and the values array contains
-                              only "value". The requirements are
-                              ANDed.
-                            type: object
-                        type: object
-                      namespaces:
-                        description: namespaces specifies which
-                          namespaces the labelSelector applies to
-                          (matches against); null or empty list
-                          means "this pod's namespace"
-                        items:
-                          type: string
-                        type: array
-                      topologyKey:
-                        description: This pod should be co-located
-                          (affinity) or not co-located (anti-affinity)
-                          with the pods matching the labelSelector
-                          in the specified namespaces, where co-located
-                          is defined as running on a node whose
-                          value of the label with key topologyKey
-                          matches that of any node on which any
-                          of the selected pods is running. Empty
-                          topologyKey is not allowed.
-                        type: string
-                    required:
-                      - topologyKey
-                    type: object
-                  weight:
-                    description: weight associated with matching
-                      the corresponding podAffinityTerm, in the
-                      range 1-100.
-                    format: int32
-                    type: integer
-                required:
-                  - podAffinityTerm
-                  - weight
-                type: object
-              type: array
-            requiredDuringSchedulingIgnoredDuringExecution:
-              description: If the anti-affinity requirements specified
-                by this field are not met at scheduling time, the
-                pod will not be scheduled onto the node. If the
-                anti-affinity requirements specified by this field
-                cease to be met at some point during pod execution
-                (e.g. due to a pod label update), the system may
-                or may not try to eventually evict the pod from
-                its node. When there are multiple elements, the
-                lists of nodes corresponding to each podAffinityTerm
-                are intersected, i.e. all terms must be satisfied.
-              items:
-                description: Defines a set of pods (namely those
-                  matching the labelSelector relative to the given
-                  namespace(s)) that this pod should be co-located
-                  (affinity) or not co-located (anti-affinity) with,
-                  where co-located is defined as running on a node
-                  whose value of the label with key <topologyKey>
-                  matches that of any node on which a pod of the
-                  set of pods is running
-                properties:
-                  labelSelector:
-                    description: A label query over a set of resources,
-                      in this case pods.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list
-                          of label selector requirements. The requirements
-                          are ANDed.
-                        items:
-                          description: A label selector requirement
-                            is a selector that contains values,
-                            a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key
-                                that the selector applies to.
-                              type: string
-                            operator:
-                              description: operator represents a
-                                key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists
-                                and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of
-                                string values. If the operator is
-                                In or NotIn, the values array must
-                                be non-empty. If the operator is
-                                Exists or DoesNotExist, the values
-                                array must be empty. This array
-                                is replaced during a strategic merge
-                                patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                            - key
-                            - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value}
-                          pairs. A single {key,value} in the matchLabels
-                          map is equivalent to an element of matchExpressions,
-                          whose key field is "key", the operator
-                          is "In", and the values array contains
-                          only "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                  namespaces:
-                    description: namespaces specifies which namespaces
-                      the labelSelector applies to (matches against);
-                      null or empty list means "this pod's namespace"
-                    items:
-                      type: string
-                    type: array
-                  topologyKey:
-                    description: This pod should be co-located (affinity)
-                      or not co-located (anti-affinity) with the
-                      pods matching the labelSelector in the specified
-                      namespaces, where co-located is defined as
-                      running on a node whose value of the label
-                      with key topologyKey matches that of any node
-                      on which any of the selected pods is running.
-                      Empty topologyKey is not allowed.
-                    type: string
-                required:
-                  - topologyKey
-                type: object
-              type: array
-          type: object
-      type: object
-    livenessProbe:
-      description: Probe describes a health check to be performed
-        against a container to determine whether it is alive or
-        ready to receive traffic.
-      properties:
-        exec:
-          description: One and only one of the following should
-            be specified. Exec specifies the action to take.
-          properties:
-            command:
-              description: Command is the command line to execute
-                inside the container, the working directory for
-                the command  is root ('/') in the container's filesystem.
-                The command is simply exec'd, it is not run inside
-                a shell, so traditional shell instructions ('|',
-                etc) won't work. To use a shell, you need to explicitly
-                call out to that shell. Exit status of 0 is treated
-                as live/healthy and non-zero is unhealthy.
-              items:
-                type: string
-              type: array
-          type: object
-        failureThreshold:
-          description: Minimum consecutive failures for the probe
-            to be considered failed after having succeeded. Defaults
-            to 3. Minimum value is 1.
-          format: int32
-          type: integer
-        httpGet:
-          description: HTTPGet specifies the http request to perform.
-          properties:
-            host:
-              description: Host name to connect to, defaults to
-                the pod IP. You probably want to set "Host" in httpHeaders
-                instead.
-              type: string
-            httpHeaders:
-              description: Custom headers to set in the request.
-                HTTP allows repeated headers.
-              items:
-                description: HTTPHeader describes a custom header
-                  to be used in HTTP probes
-                properties:
-                  name:
-                    description: The header field name
-                    type: string
-                  value:
-                    description: The header field value
-                    type: string
-                required:
-                  - name
-                  - value
-                type: object
-              type: array
-            path:
-              description: Path to access on the HTTP server.
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Name or number of the port to access
-                on the container. Number must be in the range 1
-                to 65535. Name must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-            scheme:
-              description: Scheme to use for connecting to the host.
-                Defaults to HTTP.
-              type: string
-          required:
-            - port
-          type: object
-        initialDelaySeconds:
-          description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-        periodSeconds:
-          description: How often (in seconds) to perform the probe.
-            Default to 10 seconds. Minimum value is 1.
-          format: int32
-          type: integer
-        successThreshold:
-          description: Minimum consecutive successes for the probe
-            to be considered successful after having failed. Defaults
-            to 1. Must be 1 for liveness and startup. Minimum value
-            is 1.
-          format: int32
-          type: integer
-        tcpSocket:
-          description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-          properties:
-            host:
-              description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Number or name of the port to access
-                on the container. Number must be in the range 1
-                to 65535. Name must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-          required:
-            - port
-          type: object
-        timeoutSeconds:
-          description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-      type: object
-    pdb:
-      description: RedisPodDisruptionBudget configure a PodDisruptionBudget
-        on the resource (leader/follower)
-      properties:
-        enabled:
-          type: boolean
-        maxUnavailable:
-          format: int32
-          type: integer
-        minAvailable:
-          format: int32
-          type: integer
-      type: object
-    readinessProbe:
-      description: Probe describes a health check to be performed
-        against a container to determine whether it is alive or
-        ready to receive traffic.
-      properties:
-        exec:
-          description: One and only one of the following should
-            be specified. Exec specifies the action to take.
-          properties:
-            command:
-              description: Command is the command line to execute
-                inside the container, the working directory for
-                the command  is root ('/') in the container's filesystem.
-                The command is simply exec'd, it is not run inside
-                a shell, so traditional shell instructions ('|',
-                etc) won't work. To use a shell, you need to explicitly
-                call out to that shell. Exit status of 0 is treated
-                as live/healthy and non-zero is unhealthy.
-              items:
-                type: string
-              type: array
-          type: object
-        failureThreshold:
-          description: Minimum consecutive failures for the probe
-            to be considered failed after having succeeded. Defaults
-            to 3. Minimum value is 1.
-          format: int32
-          type: integer
-        httpGet:
-          description: HTTPGet specifies the http request to perform.
-          properties:
-            host:
-              description: Host name to connect to, defaults to
-                the pod IP. You probably want to set "Host" in httpHeaders
-                instead.
-              type: string
-            httpHeaders:
-              description: Custom headers to set in the request.
-                HTTP allows repeated headers.
-              items:
-                description: HTTPHeader describes a custom header
-                  to be used in HTTP probes
-                properties:
-                  name:
-                    description: The header field name
-                    type: string
-                  value:
-                    description: The header field value
-                    type: string
-                required:
-                  - name
-                  - value
-                type: object
-              type: array
-            path:
-              description: Path to access on the HTTP server.
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Name or number of the port to access
-                on the container. Number must be in the range 1
-                to 65535. Name must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-            scheme:
-              description: Scheme to use for connecting to the host.
-                Defaults to HTTP.
-              type: string
-          required:
-            - port
-          type: object
-        initialDelaySeconds:
-          description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-        periodSeconds:
-          description: How often (in seconds) to perform the probe.
-            Default to 10 seconds. Minimum value is 1.
-          format: int32
-          type: integer
-        successThreshold:
-          description: Minimum consecutive successes for the probe
-            to be considered successful after having failed. Defaults
-            to 1. Must be 1 for liveness and startup. Minimum value
-            is 1.
-          format: int32
-          type: integer
-        tcpSocket:
-          description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-          properties:
-            host:
-              description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-              type: string
-            port:
-              anyOf:
-                - type: integer
-                - type: string
-              description: Number or name of the port to access
-                on the container. Number must be in the range 1
-                to 65535. Name must be an IANA_SVC_NAME.
-              x-kubernetes-int-or-string: true
-          required:
-            - port
-          type: object
-        timeoutSeconds:
-          description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-          format: int32
-          type: integer
-      type: object
-    redisConfig:
-      description: RedisConfig defines the external configuration
-        of Redis
-      properties:
-        additionalRedisConfig:
-          type: string
-      type: object
-    replicas:
-      format: int32
-      minimum: 3
-      type: integer
-  type: object
-resources:
-  description: ResourceRequirements describes the compute resource
-    requirements.
-  properties:
-    limits:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-      type: object
-    requests:
-      additionalProperties:
-        anyOf:
-          - type: integer
-          - type: string
-        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-        x-kubernetes-int-or-string: true
-      description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-      type: object
-  type: object
-securityContext:
-  description: PodSecurityContext holds pod-level security attributes
-    and common container settings. Some fields are also present
-    in container.securityContext.  Field values of container.securityContext
-    take precedence over field values of PodSecurityContext.
-  properties:
-    fsGroup:
-      description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-      format: int64
-      type: integer
-    fsGroupChangePolicy:
-      description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified defaults to "Always".'
-      type: string
-    runAsGroup:
-      description: The GID to run the entrypoint of the container
-        process. Uses runtime default if unset. May also be set
-        in SecurityContext.  If set in both SecurityContext and
-        PodSecurityContext, the value specified in SecurityContext
-        takes precedence for that container.
-      format: int64
-      type: integer
-    runAsNonRoot:
-      description: Indicates that the container must run as a non-root
-        user. If true, the Kubelet will validate the image at runtime
-        to ensure that it does not run as UID 0 (root) and fail
-        to start the container if it does. If unset or false, no
-        such validation will be performed. May also be set in SecurityContext.  If
-        set in both SecurityContext and PodSecurityContext, the
-        value specified in SecurityContext takes precedence.
-      type: boolean
-    runAsUser:
-      description: The UID to run the entrypoint of the container
-        process. Defaults to user specified in image metadata if
-        unspecified. May also be set in SecurityContext.  If set
-        in both SecurityContext and PodSecurityContext, the value
-        specified in SecurityContext takes precedence for that container.
-      format: int64
-      type: integer
-    seLinuxOptions:
-      description: The SELinux context to be applied to all containers.
-        If unspecified, the container runtime will allocate a random
-        SELinux context for each container.  May also be set in
-        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-        the value specified in SecurityContext takes precedence
-        for that container.
-      properties:
-        level:
-          description: Level is SELinux level label that applies
-            to the container.
-          type: string
-        role:
-          description: Role is a SELinux role label that applies
-            to the container.
-          type: string
-        type:
-          description: Type is a SELinux type label that applies
-            to the container.
-          type: string
-        user:
-          description: User is a SELinux user label that applies
-            to the container.
-          type: string
-      type: object
-    seccompProfile:
-      description: The seccomp options to use by the containers
-        in this pod.
-      properties:
-        localhostProfile:
-          description: localhostProfile indicates a profile defined
-            in a file on the node should be used. The profile must
-            be preconfigured on the node to work. Must be a descending
-            path, relative to the kubelet's configured seccomp profile
-            location. Must only be set if type is "Localhost".
-          type: string
-        type:
-          description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-          type: string
-      required:
-        - type
-      type: object
-    supplementalGroups:
-      description: A list of groups applied to the first process
-        run in each container, in addition to the container's primary
-        GID.  If unspecified, no groups will be added to any container.
-      items:
-        format: int64
-        type: integer
-      type: array
-    sysctls:
-      description: Sysctls hold a list of namespaced sysctls used
-        for the pod. Pods with unsupported sysctls (by the container
-        runtime) might fail to launch.
-      items:
-        description: Sysctl defines a kernel parameter to be set
-        properties:
-          name:
-            description: Name of a property to set
-            type: string
-          value:
-            description: Value of a property to set
-            type: string
-        required:
-          - name
-          - value
-        type: object
-      type: array
-    windowsOptions:
-      description: The Windows specific settings applied to all
-        containers. If unspecified, the options within a container's
-        SecurityContext will be used. If set in both SecurityContext
-        and PodSecurityContext, the value specified in SecurityContext
-        takes precedence.
-      properties:
-        gmsaCredentialSpec:
-          description: GMSACredentialSpec is where the GMSA admission
-            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-            inlines the contents of the GMSA credential spec named
-            by the GMSACredentialSpecName field.
-          type: string
-        gmsaCredentialSpecName:
-          description: GMSACredentialSpecName is the name of the
-            GMSA credential spec to use.
-          type: string
-        runAsUserName:
-          description: The UserName in Windows to run the entrypoint
-            of the container process. Defaults to the user specified
-            in image metadata if unspecified. May also be set in
-            PodSecurityContext. If set in both SecurityContext and
-            PodSecurityContext, the value specified in SecurityContext
-            takes precedence.
-          type: string
-        resizeStatus:
-          description: ResizeStatus stores status of resize operation.
-            ResizeStatus is not set by default but when expansion
-            is complete resizeStatus is set to empty string by resize
-            controller or kubelet. This is an alpha field and requires
-            enabling RecoverVolumeExpansionFailure feature.
-          type: string
-      type: object
-  type: object
-sidecars:
-  items:
-    description: Sidecar for each Redis pods
-    properties:
-      env:
-        items:
-          description: EnvVar represents an environment variable
-            present in a Container.
-          properties:
-            name:
-              description: Name of the environment variable. Must
-                be a C_IDENTIFIER.
-              type: string
-            value:
-              description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
-              type: string
-            valueFrom:
-              description: Source for the environment variable's
-                value. Cannot be used if value is not empty.
-              properties:
-                configMapKeyRef:
-                  description: Selects a key of a ConfigMap.
-                  properties:
-                    key:
-                      description: The key to select.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                      type: string
-                    optional:
-                      description: Specify whether the ConfigMap
-                        or its key must be defined
-                      type: boolean
-                  required:
-                    - key
-                  type: object
-                fieldRef:
-                  description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
-                  properties:
-                    apiVersion:
-                      description: Version of the schema the FieldPath
-                        is written in terms of, defaults to "v1".
-                      type: string
-                    fieldPath:
-                      description: Path of the field to select in
-                        the specified API version.
-                      type: string
-                  required:
-                    - fieldPath
-                  type: object
-                resourceFieldRef:
-                  description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
-                  properties:
-                    containerName:
-                      description: 'Container name: required for
-                                          volumes, optional for env vars'
-                      type: string
-                    divisor:
-                      anyOf:
-                        - type: integer
-                        - type: string
-                      description: Specifies the output format of
-                        the exposed resources, defaults to "1"
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    resource:
-                      description: 'Required: resource to select'
-                      type: string
-                  required:
-                    - resource
-                  type: object
-                secretKeyRef:
-                  description: Selects a key of a secret in the
-                    pod's namespace
-                  properties:
-                    key:
-                      description: The key of the secret to select
-                        from.  Must be a valid secret key.
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                      type: string
-                    optional:
-                      description: Specify whether the Secret or
-                        its key must be defined
-                      type: boolean
-                  required:
-                    - key
-                  type: object
-              type: object
-          required:
-            - name
-          type: object
-        type: array
-      image:
-        type: string
-      imagePullPolicy:
-        description: PullPolicy describes a policy for if/when to
-          pull a container image
-        type: string
-      name:
-        type: string
-      resources:
-        description: ResourceRequirements describes the compute
-          resource requirements.
-        properties:
-          limits:
-            additionalProperties:
-              anyOf:
-                - type: integer
-                - type: string
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-            type: object
-          requests:
-            additionalProperties:
-              anyOf:
-                - type: integer
-                - type: string
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-              x-kubernetes-int-or-string: true
-            description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-            type: object
-        type: object
-    required:
-      - image
-      - name
-    type: object
-  type: array
-storage:
-  description: Storage is the inteface to add pvc and pv support
-    in redis
-  properties:
-    volumeClaimTemplate:
-      description: PersistentVolumeClaim is a user's request for
-        and claim to a persistent volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema
-                              of this representation of an object. Servers should
-                              convert recognized schemas to the latest internal value,
-                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the
-                              REST resource this object represents. Servers may infer
-                              this from the endpoint the client submits requests to.
-                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-          type: object
-        spec:
-          description: 'Spec defines the desired characteristics
-                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-          properties:
-            accessModes:
-              description: 'AccessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-              items:
-                type: string
-              type: array
-            dataSource:
-              description: 'This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                  * An existing custom resource/object that implements
-                                  data population (Alpha) In order to use VolumeSnapshot
-                                  object types, the appropriate feature gate must
-                                  be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                  If the provisioner or an external controller can
-                                  support the specified data source, it will create
-                                  a new volume based on the contents of the specified
-                                  data source. If the specified data source is not
-                                  supported, the volume will not be created and the
-                                  failure will be reported as an event. In the future,
-                                  we plan to support more data source types and the
-                                  behavior of the provisioner may change.'
-              properties:
-                apiGroup:
-                  description: APIGroup is the group for the resource
-                    being referenced. If APIGroup is not specified,
-                    the specified Kind must be in the core API group.
-                    For any other third-party types, APIGroup is
-                    required.
-                  type: string
-                kind:
-                  description: Kind is the type of resource being
-                    referenced
-                  type: string
-                name:
-                  description: Name is the name of resource being
-                    referenced
-                  type: string
-              required:
-                - kind
-                - name
-              type: object
-            resources:
-              description: 'Resources represents the minimum resources
-                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-              properties:
-                limits:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                requests:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-              type: object
-            selector:
-              description: A label query over volumes to consider
-                for binding.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label
-                    selector requirements. The requirements are
-                    ANDed.
-                  items:
-                    description: A label selector requirement is
-                      a selector that contains values, a key, and
-                      an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the
-                          selector applies to.
-                        type: string
-                      operator:
-                        description: operator represents a key's
-                          relationship to a set of values. Valid
-                          operators are In, NotIn, Exists and DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string
-                          values. If the operator is In or NotIn,
-                          the values array must be non-empty. If
-                          the operator is Exists or DoesNotExist,
-                          the values array must be empty. This array
-                          is replaced during a strategic merge patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                      - key
-                      - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value}
-                    pairs. A single {key,value} in the matchLabels
-                    map is equivalent to an element of matchExpressions,
-                    whose key field is "key", the operator is "In",
-                    and the values array contains only "value".
-                    The requirements are ANDed.
-                  type: object
-              type: object
-            storageClassName:
-              description: 'Name of the StorageClass required by
-                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-              type: string
-            volumeMode:
-              description: volumeMode defines what type of volume
-                is required by the claim. Value of Filesystem is
-                implied when not included in claim spec.
-              type: string
-            volumeName:
-              description: VolumeName is the binding reference to
-                the PersistentVolume backing this claim.
-              type: string
-          type: object
-        status:
-          description: 'Status represents the current information/status
-                              of a persistent volume claim. Read-only. More info:
-                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-          properties:
-            accessModes:
-              description: 'AccessModes contains the actual access
-                                  modes the volume backing the PVC has. More info:
-                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-              items:
-                type: string
-              type: array
-            capacity:
-              additionalProperties:
-                anyOf:
-                  - type: integer
-                  - type: string
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              description: Represents the actual resources of the
-                underlying volume.
-              type: object
-            conditions:
-              description: Current Condition of persistent volume
-                claim. If underlying persistent volume is being
-                resized then the Condition will be set to 'ResizeStarted'.
-              items:
-                description: PersistentVolumeClaimCondition contails
-                  details about state of pvc
-                properties:
-                  lastProbeTime:
-                    description: Last time we probed the condition.
-                    format: date-time
-                    type: string
-                  lastTransitionTime:
-                    description: Last time the condition transitioned
-                      from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human-readable message indicating
-                      details about last transition.
-                    type: string
-                  reason:
-                    description: Unique, this should be a short,
-                      machine understandable string that gives the
-                      reason for condition's last transition. If
-                      it reports "ResizeStarted" that means the
-                      underlying persistent volume is being resized.
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    description: PersistentVolumeClaimConditionType
-                      is a valid value of PersistentVolumeClaimCondition.Type
-                    type: string
-                required:
-                  - status
-                  - type
-                type: object
-              type: array
-            phase:
-              description: Phase represents the current phase of
-                PersistentVolumeClaim.
-              type: string
-          type: object
-      type: object
-  type: object
-tolerations:
-  items:
-    description: The pod this Toleration is attached to tolerates
-      any taint that matches the triple <key,value,effect> using
-      the matching operator <operator>.
-    properties:
-      effect:
-        description: Effect indicates the taint effect to match.
-          Empty means match all taint effects. When specified, allowed
-          values are NoSchedule, PreferNoSchedule and NoExecute.
-        type: string
-      key:
-        description: Key is the taint key that the toleration applies
-          to. Empty means match all taint keys. If the key is empty,
-          operator must be Exists; this combination means to match
-          all values and all keys.
-        type: string
-      operator:
-        description: Operator represents a key's relationship to
-          the value. Valid operators are Exists and Equal. Defaults
-          to Equal. Exists is equivalent to wildcard for value,
-          so that a pod can tolerate all taints of a particular
-          category.
-        type: string
-      tolerationSeconds:
-        description: TolerationSeconds represents the period of
-          time the toleration (which must be of effect NoExecute,
-          otherwise this field is ignored) tolerates the taint.
-          By default, it is not set, which means tolerate the taint
-          forever (do not evict). Zero and negative values will
-          be treated as 0 (evict immediately) by the system.
-        format: int64
-        type: integer
-      value:
-        description: Value is the taint value the toleration matches
-          to. If the operator is Exists, the value should be empty,
-          otherwise just a regular string.
-        type: string
-    type: object
-  type: array
-required:
-  - clusterSize
-  - kubernetesConfig
-type: object
-type: object
-required:
-  - spec
-type: object
-served: true
-storage: true
-subresources:
-  status: {}
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/redis-operator/crds/redis.yaml
+++ b/charts/redis-operator/crds/redis.yaml
@@ -15,40 +15,40 @@ spec:
     singular: redis
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Redis is the Schema for the redis API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Redis is the Schema for the redis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: RedisSpec defines the desired state of Redis
-              properties:
-                TLS:
-                  description: TLS Configuration for redis instances
-                  properties:
-                    ca:
-                      type: string
-                    cert:
-                      type: string
-                    key:
-                      type: string
-                    secret:
-                      description: Reference to secret which contains the certificates
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits used to set permissions
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RedisSpec defines the desired state of Redis
+            properties:
+              TLS:
+                description: TLS Configuration for redis instances
+                properties:
+                  ca:
+                    type: string
+                  cert:
+                    type: string
+                  key:
+                    type: string
+                  secret:
+                    description: Reference to secret which contains the certificates
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits used to set permissions
                           on created files by default. Must be an octal value between
                           0000 and 0777 or a decimal value between 0 and 511. YAML
                           accepts both octal and decimal values, JSON requires decimal
@@ -56,26 +56,26 @@ spec:
                           the path are not affected by this setting. This might be
                           in conflict with other options that affect the file mode,
                           like fsGroup, and the result can be other mode bits set.'
-                          format: int32
-                          type: integer
+                        format: int32
+                        type: integer
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
                         items:
-                          description: If unspecified, each key-value pair in the Data
-                            field of the referenced Secret will be projected into the
-                            volume as a file whose name is the key and content is the
-                            value. If specified, the listed keys will be projected into
-                            the specified paths, and unlisted keys will not be present.
-                            If a key is specified which is not present in the Secret,
-                            the volume setup will error unless it is marked optional.
-                            Paths must be relative and may not contain the '..' path
-                            or start with '..'.
-                          items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: The key to project.
-                                type: string
-                              mode:
-                                description: 'Optional: mode bits used to set permissions
+                          description: Maps a string key to a path within a volume.
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits used to set permissions
                                 on this file. Must be an octal value between 0000
                                 and 0777 or a decimal value between 0 and 511. YAML
                                 accepts both octal and decimal values, JSON requires
@@ -84,1233 +84,1233 @@ spec:
                                 conflict with other options that affect the file mode,
                                 like fsGroup, and the result can be other mode bits
                                 set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: The relative path of the file to map the
-                                  key to. May not be an absolute path. May not contain
-                                  the path element '..'. May not start with the string
-                                  '..'.
-                                type: string
-                            required:
-                              - key
-                              - path
-                            type: object
-                          type: array
-                        optional:
-                          description: Specify whether the Secret or its keys must be
-                            defined
-                          type: boolean
-                        secretName:
-                          description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                          type: string
-                      type: object
-                  required:
-                    - secret
-                  type: object
-                affinity:
-                  description: Affinity is a group of affinity scheduling rules.
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the
-                        pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node matches
-                            the corresponding matchExpressions; the node(s) with the
-                            highest sum are the most preferred.
-                          items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects (i.e.
-                              is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with the
-                                  corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                description: Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to an update), the system may or may not try to
-                            eventually evict the pod from its node.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed. The
-                                  TopologySelectorTerm type implements a subset of the
-                                  NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
+                              format: int32
+                              type: integer
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
                           required:
-                            - nodeSelectorTerms
+                          - key
+                          - path
                           type: object
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
-                            node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
+                        type: array
+                      optional:
+                        description: Specify whether the Secret or its keys must be
+                          defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                    type: object
+                required:
+                - secret
+                type: object
+              affinity:
+                description: Affinity is a group of affinity scheduling rules.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
                                     type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
+                                          type: string
                                         type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
+                                    required:
+                                    - key
+                                    - operator
                                     type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to a pod label update), the system may or may
-                            not try to eventually evict the pod from its node. When
-                            there are multiple elements, the lists of nodes corresponding
-                            to each podAffinityTerm are intersected, i.e. all terms
-                            must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                description: A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
-                                  This field is beta-level and is only honored when
-                                  PodAffinityNamespaceSelector feature is enabled.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
-                                  Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates one
-                            or more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling anti-affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
-                            node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by
-                            this field are not met at scheduling time, the pod will
-                            not be scheduled onto the node. If the anti-affinity requirements
-                            specified by this field cease to be met at some point during
-                            pod execution (e.g. due to a pod label update), the system
-                            may or may not try to eventually evict the pod from its
-                            node. When there are multiple elements, the lists of nodes
-                            corresponding to each podAffinityTerm are intersected, i.e.
-                            all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                description: A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
-                                  This field is beta-level and is only honored when
-                                  PodAffinityNamespaceSelector feature is enabled.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
-                                  Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                kubernetesConfig:
-                  description: KubernetesConfig will be the JSON struct for Basic Redis
-                    Config
-                  properties:
-                    image:
-                      type: string
-                    imagePullPolicy:
-                      description: PullPolicy describes a policy for if/when to pull
-                        a container image
-                      type: string
-                    imagePullSecrets:
-                      items:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same namespace.
+                                  type: array
+                              type: object
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
                         properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                            type: array
+                        required:
+                        - nodeSelectorTerms
                         type: object
-                      type: array
-                    redisSecret:
-                      description: ExistingPasswordSecret is the struct to access the
-                        existing secret
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is beta-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces. This field is beta-level
+                                    and is only honored when PodAffinityNamespaceSelector
+                                    feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                                This field is beta-level and is only honored when
+                                PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              kubernetesConfig:
+                description: KubernetesConfig will be the JSON struct for Basic Redis
+                  Config
+                properties:
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
                       properties:
-                        key:
-                          type: string
                         name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
-                    resources:
-                      description: ResourceRequirements describes the compute resource
-                        requirements.
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
+                    type: array
+                  redisSecret:
+                    description: ExistingPasswordSecret is the struct to access the
+                      existing secret
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    type: object
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
                           resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              livenessProbe:
+                description: Probe describes a health check to be performed against
+                  a container to determine whether it is alive or ready to receive
+                  traffic.
+                properties:
+                  exec:
+                    description: Exec specifies the action to take.
+                    properties:
+                      command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies an action involving a GRPC port. This
+                      is an alpha field and requires enabling GRPCContainerProbe feature
+                      gate.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        description: "Service is the name of the service to place
+                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                          \n If this is not specified, the default behavior is defined
+                          by gRPC."
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies the http request to perform.
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: The header field name
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
                           type: object
-                      type: object
-                  required:
-                    - image
-                  type: object
-                livenessProbe:
-                  description: Probe describes a health check to be performed against
-                    a container to determine whether it is alive or ready to receive
-                    traffic.
-                  properties:
-                    exec:
-                      description: Exec specifies the action to take.
-                      properties:
-                        command:
-                          description: Command is the command line to execute inside
-                            the container, the working directory for the command  is
-                            root ('/') in the container's filesystem. The command is
-                            simply exec'd, it is not run inside a shell, so traditional
-                            shell instructions ('|', etc) won't work. To use a shell,
-                            you need to explicitly call out to that shell. Exit status
-                            of 0 is treated as live/healthy and non-zero is unhealthy.
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    failureThreshold:
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
-                      format: int32
-                      type: integer
-                    grpc:
-                      description: GRPC specifies an action involving a GRPC port. This
-                        is an alpha field and requires enabling GRPCContainerProbe feature
-                        gate.
-                      properties:
-                        port:
-                          description: Port number of the gRPC service. Number must
-                            be in the range 1 to 65535.
-                          format: int32
-                          type: integer
-                        service:
-                          description: "Service is the name of the service to place
-                          in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                          \n If this is not specified, the default behavior is defined
-                          by gRPC."
-                          type: string
-                      required:
-                        - port
-                      type: object
-                    httpGet:
-                      description: HTTPGet specifies the http request to perform.
-                      properties:
-                        host:
-                          description: Host name to connect to, defaults to the pod
-                            IP. You probably want to set "Host" in httpHeaders instead.
-                          type: string
-                        httpHeaders:
-                          description: Custom headers to set in the request. HTTP allows
-                            repeated headers.
-                          items:
-                            description: HTTPHeader describes a custom header to be
-                              used in HTTP probes
-                            properties:
-                              name:
-                                description: The header field name
-                                type: string
-                              value:
-                                description: The header field value
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        path:
-                          description: Path to access on the HTTP server.
-                          type: string
-                        port:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          description: Name or number of the port to access on the container.
-                            Number must be in the range 1 to 65535. Name must be an
-                            IANA_SVC_NAME.
-                          x-kubernetes-int-or-string: true
-                        scheme:
-                          description: Scheme to use for connecting to the host. Defaults
-                            to HTTP.
-                          type: string
-                      required:
-                        - port
-                      type: object
-                    initialDelaySeconds:
-                      description: 'Number of seconds after the container has started
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
                       before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                      format: int32
-                      type: integer
-                    periodSeconds:
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
-                      format: int32
-                      type: integer
-                    successThreshold:
-                      description: Minimum consecutive successes for the probe to be
-                        considered successful after having failed. Defaults to 1. Must
-                        be 1 for liveness and startup. Minimum value is 1.
-                      format: int32
-                      type: integer
-                    tcpSocket:
-                      description: TCPSocket specifies an action involving a TCP port.
-                      properties:
-                        host:
-                          description: 'Optional: Host name to connect to, defaults
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies an action involving a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
                           to the pod IP.'
-                          type: string
-                        port:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          description: Number or name of the port to access on the container.
-                            Number must be in the range 1 to 65535. Name must be an
-                            IANA_SVC_NAME.
-                          x-kubernetes-int-or-string: true
-                      required:
-                        - port
-                      type: object
-                    terminationGracePeriodSeconds:
-                      description: Optional duration in seconds the pod needs to terminate
-                        gracefully upon probe failure. The grace period is the duration
-                        in seconds after the processes running in the pod are sent a
-                        termination signal and the time when the processes are forcibly
-                        halted with a kill signal. Set this value longer than the expected
-                        cleanup time for your process. If this value is nil, the pod's
-                        terminationGracePeriodSeconds will be used. Otherwise, this
-                        value overrides the value provided by the pod spec. Value must
-                        be non-negative integer. The value zero indicates stop immediately
-                        via the kill signal (no opportunity to shut down). This is a
-                        beta field and requires enabling ProbeTerminationGracePeriod
-                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                        is used if unset.
-                      format: int64
-                      type: integer
-                    timeoutSeconds:
-                      description: 'Number of seconds after which the probe times out.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure. The grace period is the duration
+                      in seconds after the processes running in the pod are sent a
+                      termination signal and the time when the processes are forcibly
+                      halted with a kill signal. Set this value longer than the expected
+                      cleanup time for your process. If this value is nil, the pod's
+                      terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec. Value must
+                      be non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). This is a
+                      beta field and requires enabling ProbeTerminationGracePeriod
+                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                      is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
                       Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                      format: int32
-                      type: integer
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  type: object
-                priorityClassName:
+                    format: int32
+                    type: integer
+                type: object
+              nodeSelector:
+                additionalProperties:
                   type: string
-                readinessProbe:
-                  description: Probe describes a health check to be performed against
-                    a container to determine whether it is alive or ready to receive
-                    traffic.
-                  properties:
-                    exec:
-                      description: Exec specifies the action to take.
-                      properties:
-                        command:
-                          description: Command is the command line to execute inside
-                            the container, the working directory for the command  is
-                            root ('/') in the container's filesystem. The command is
-                            simply exec'd, it is not run inside a shell, so traditional
-                            shell instructions ('|', etc) won't work. To use a shell,
-                            you need to explicitly call out to that shell. Exit status
-                            of 0 is treated as live/healthy and non-zero is unhealthy.
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    failureThreshold:
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
-                      format: int32
-                      type: integer
-                    grpc:
-                      description: GRPC specifies an action involving a GRPC port. This
-                        is an alpha field and requires enabling GRPCContainerProbe feature
-                        gate.
-                      properties:
-                        port:
-                          description: Port number of the gRPC service. Number must
-                            be in the range 1 to 65535.
-                          format: int32
-                          type: integer
-                        service:
-                          description: "Service is the name of the service to place
+                type: object
+              priorityClassName:
+                type: string
+              readinessProbe:
+                description: Probe describes a health check to be performed against
+                  a container to determine whether it is alive or ready to receive
+                  traffic.
+                properties:
+                  exec:
+                    description: Exec specifies the action to take.
+                    properties:
+                      command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
+                    format: int32
+                    type: integer
+                  grpc:
+                    description: GRPC specifies an action involving a GRPC port. This
+                      is an alpha field and requires enabling GRPCContainerProbe feature
+                      gate.
+                    properties:
+                      port:
+                        description: Port number of the gRPC service. Number must
+                          be in the range 1 to 65535.
+                        format: int32
+                        type: integer
+                      service:
+                        description: "Service is the name of the service to place
                           in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
                           \n If this is not specified, the default behavior is defined
                           by gRPC."
-                          type: string
-                      required:
-                        - port
-                      type: object
-                    httpGet:
-                      description: HTTPGet specifies the http request to perform.
-                      properties:
-                        host:
-                          description: Host name to connect to, defaults to the pod
-                            IP. You probably want to set "Host" in httpHeaders instead.
-                          type: string
-                        httpHeaders:
-                          description: Custom headers to set in the request. HTTP allows
-                            repeated headers.
-                          items:
-                            description: HTTPHeader describes a custom header to be
-                              used in HTTP probes
-                            properties:
-                              name:
-                                description: The header field name
-                                type: string
-                              value:
-                                description: The header field value
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        path:
-                          description: Path to access on the HTTP server.
-                          type: string
-                        port:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          description: Name or number of the port to access on the container.
-                            Number must be in the range 1 to 65535. Name must be an
-                            IANA_SVC_NAME.
-                          x-kubernetes-int-or-string: true
-                        scheme:
-                          description: Scheme to use for connecting to the host. Defaults
-                            to HTTP.
-                          type: string
-                      required:
-                        - port
-                      type: object
-                    initialDelaySeconds:
-                      description: 'Number of seconds after the container has started
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  httpGet:
+                    description: HTTPGet specifies the http request to perform.
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: The header field name
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
                       before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                      format: int32
-                      type: integer
-                    periodSeconds:
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
-                      format: int32
-                      type: integer
-                    successThreshold:
-                      description: Minimum consecutive successes for the probe to be
-                        considered successful after having failed. Defaults to 1. Must
-                        be 1 for liveness and startup. Minimum value is 1.
-                      format: int32
-                      type: integer
-                    tcpSocket:
-                      description: TCPSocket specifies an action involving a TCP port.
-                      properties:
-                        host:
-                          description: 'Optional: Host name to connect to, defaults
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: TCPSocket specifies an action involving a TCP port.
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
                           to the pod IP.'
-                          type: string
-                        port:
-                          anyOf:
-                            - type: integer
-                            - type: string
-                          description: Number or name of the port to access on the container.
-                            Number must be in the range 1 to 65535. Name must be an
-                            IANA_SVC_NAME.
-                          x-kubernetes-int-or-string: true
-                      required:
-                        - port
-                      type: object
-                    terminationGracePeriodSeconds:
-                      description: Optional duration in seconds the pod needs to terminate
-                        gracefully upon probe failure. The grace period is the duration
-                        in seconds after the processes running in the pod are sent a
-                        termination signal and the time when the processes are forcibly
-                        halted with a kill signal. Set this value longer than the expected
-                        cleanup time for your process. If this value is nil, the pod's
-                        terminationGracePeriodSeconds will be used. Otherwise, this
-                        value overrides the value provided by the pod spec. Value must
-                        be non-negative integer. The value zero indicates stop immediately
-                        via the kill signal (no opportunity to shut down). This is a
-                        beta field and requires enabling ProbeTerminationGracePeriod
-                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                        is used if unset.
-                      format: int64
-                      type: integer
-                    timeoutSeconds:
-                      description: 'Number of seconds after which the probe times out.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate
+                      gracefully upon probe failure. The grace period is the duration
+                      in seconds after the processes running in the pod are sent a
+                      termination signal and the time when the processes are forcibly
+                      halted with a kill signal. Set this value longer than the expected
+                      cleanup time for your process. If this value is nil, the pod's
+                      terminationGracePeriodSeconds will be used. Otherwise, this
+                      value overrides the value provided by the pod spec. Value must
+                      be non-negative integer. The value zero indicates stop immediately
+                      via the kill signal (no opportunity to shut down). This is a
+                      beta field and requires enabling ProbeTerminationGracePeriod
+                      feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                      is used if unset.
+                    format: int64
+                    type: integer
+                  timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
                       Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                      format: int32
-                      type: integer
-                  type: object
-                redisConfig:
-                  description: RedisConfig defines the external configuration of Redis
-                  properties:
-                    additionalRedisConfig:
-                      type: string
-                  type: object
-                redisExporter:
-                  description: RedisExporter interface will have the information for
-                    redis exporter related stuff
-                  properties:
-                    enabled:
-                      type: boolean
-                    env:
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
+                    format: int32
+                    type: integer
+                type: object
+              redisConfig:
+                description: RedisConfig defines the external configuration of Redis
+                properties:
+                  additionalRedisConfig:
+                    type: string
+                type: object
+              redisExporter:
+                description: RedisExporter interface will have the information for
+                  redis exporter related stuff
+                properties:
+                  enabled:
+                    type: boolean
+                  env:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
                             the container and any service environment variables. If
                             a variable cannot be resolved, the reference in the input
@@ -1319,6 +1319,322 @@ spec:
                             "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                             Escaped references will never be expanded, regardless
                             of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                required:
+                - image
+                type: object
+              securityContext:
+                description: PodSecurityContext holds pod-level security attributes
+                  and common container settings. Some fields are also present in container.securityContext.  Field
+                  values of container.securityContext take precedence over field values
+                  of PodSecurityContext.
+                properties:
+                  fsGroup:
+                    description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume. Note that this field cannot be set when spec.os.name
+                      is windows."
+                    format: int64
+                    type: integer
+                  fsGroupChangePolicy:
+                    description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used. Note that this field cannot
+                      be set when spec.os.name is windows.'
+                    type: string
+                  runAsGroup:
+                    description: The GID to run the entrypoint of the container process.
+                      Uses runtime default if unset. May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  runAsNonRoot:
+                    description: Indicates that the container must run as a non-root
+                      user. If true, the Kubelet will validate the image at runtime
+                      to ensure that it does not run as UID 0 (root) and fail to start
+                      the container if it does. If unset or false, no such validation
+                      will be performed. May also be set in SecurityContext.  If set
+                      in both SecurityContext and PodSecurityContext, the value specified
+                      in SecurityContext takes precedence.
+                    type: boolean
+                  runAsUser:
+                    description: The UID to run the entrypoint of the container process.
+                      Defaults to user specified in image metadata if unspecified.
+                      May also be set in SecurityContext.  If set in both SecurityContext
+                      and PodSecurityContext, the value specified in SecurityContext
+                      takes precedence for that container. Note that this field cannot
+                      be set when spec.os.name is windows.
+                    format: int64
+                    type: integer
+                  seLinuxOptions:
+                    description: The SELinux context to be applied to all containers.
+                      If unspecified, the container runtime will allocate a random
+                      SELinux context for each container.  May also be set in SecurityContext.  If
+                      set in both SecurityContext and PodSecurityContext, the value
+                      specified in SecurityContext takes precedence for that container.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    properties:
+                      level:
+                        description: Level is SELinux level label that applies to
+                          the container.
+                        type: string
+                      role:
+                        description: Role is a SELinux role label that applies to
+                          the container.
+                        type: string
+                      type:
+                        description: Type is a SELinux type label that applies to
+                          the container.
+                        type: string
+                      user:
+                        description: User is a SELinux user label that applies to
+                          the container.
+                        type: string
+                    type: object
+                  seccompProfile:
+                    description: The seccomp options to use by the containers in this
+                      pod. Note that this field cannot be set when spec.os.name is
+                      windows.
+                    properties:
+                      localhostProfile:
+                        description: localhostProfile indicates a profile defined
+                          in a file on the node should be used. The profile must be
+                          preconfigured on the node to work. Must be a descending
+                          path, relative to the kubelet's configured seccomp profile
+                          location. Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  supplementalGroups:
+                    description: A list of groups applied to the first process run
+                      in each container, in addition to the container's primary GID.  If
+                      unspecified, no groups will be added to any container. Note
+                      that this field cannot be set when spec.os.name is windows.
+                    items:
+                      format: int64
+                      type: integer
+                    type: array
+                  sysctls:
+                    description: Sysctls hold a list of namespaced sysctls used for
+                      the pod. Pods with unsupported sysctls (by the container runtime)
+                      might fail to launch. Note that this field cannot be set when
+                      spec.os.name is windows.
+                    items:
+                      description: Sysctl defines a kernel parameter to be set
+                      properties:
+                        name:
+                          description: Name of a property to set
+                          type: string
+                        value:
+                          description: Value of a property to set
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  windowsOptions:
+                    description: The Windows specific settings applied to all containers.
+                      If unspecified, the options within a container's SecurityContext
+                      will be used. If set in both SecurityContext and PodSecurityContext,
+                      the value specified in SecurityContext takes precedence. Note
+                      that this field cannot be set when spec.os.name is linux.
+                    properties:
+                      gmsaCredentialSpec:
+                        description: GMSACredentialSpec is where the GMSA admission
+                          webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                          inlines the contents of the GMSA credential spec named by
+                          the GMSACredentialSpecName field.
+                        type: string
+                      gmsaCredentialSpecName:
+                        description: GMSACredentialSpecName is the name of the GMSA
+                          credential spec to use.
+                        type: string
+                      hostProcess:
+                        description: HostProcess determines if a container should
+                          be run as a 'Host Process' container. This field is alpha-level
+                          and will only be honored by components that enable the WindowsHostProcessContainers
+                          feature flag. Setting this field without the feature flag
+                          will result in errors when validating the Pod. All of a
+                          Pod's containers must have the same effective HostProcess
+                          value (it is not allowed to have a mix of HostProcess containers
+                          and non-HostProcess containers).  In addition, if HostProcess
+                          is true then HostNetwork must also be set to true.
+                        type: boolean
+                      runAsUserName:
+                        description: The UserName in Windows to run the entrypoint
+                          of the container process. Defaults to the user specified
+                          in image metadata if unspecified. May also be set in PodSecurityContext.
+                          If set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: string
+                    type: object
+                type: object
+              sidecars:
+                items:
+                  description: Sidecar for each Redis pods
+                  properties:
+                    env:
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
                             type: string
                           valueFrom:
                             description: Source for the environment variable's value.
@@ -1331,23 +1647,24 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
                                 properties:
                                   apiVersion:
                                     description: Version of the schema the FieldPath
@@ -1358,22 +1675,23 @@ spec:
                                       specified API version.
                                     type: string
                                 required:
-                                  - fieldPath
+                                - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
                                 properties:
                                   containerName:
                                     description: 'Container name: required for volumes,
-                                    optional for env vars'
+                                      optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
-                                      - type: integer
-                                      - type: string
+                                    - type: integer
+                                    - type: string
                                     description: Specifies the output format of the
                                       exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -1382,7 +1700,7 @@ spec:
                                     description: 'Required: resource to select'
                                     type: string
                                 required:
-                                  - resource
+                                - resource
                                 type: object
                               secretKeyRef:
                                 description: Selects a key of a secret in the pod's
@@ -1393,20 +1711,21 @@ spec:
                                       be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
+                                    description: Specify whether the Secret or its
+                                      key must be defined
                                     type: boolean
                                 required:
-                                  - key
+                                - key
                                 type: object
                             type: object
                         required:
-                          - name
+                        - name
                         type: object
                       type: array
                     image:
@@ -1415,6 +1734,8 @@ spec:
                       description: PullPolicy describes a policy for if/when to pull
                         a container image
                       type: string
+                    name:
+                      type: string
                     resources:
                       description: ResourceRequirements describes the compute resource
                         requirements.
@@ -1422,388 +1743,67 @@ spec:
                         limits:
                           additionalProperties:
                             anyOf:
-                              - type: integer
-                              - type: string
+                            - type: integer
+                            - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                         requests:
                           additionalProperties:
                             anyOf:
-                              - type: integer
-                              - type: string
+                            - type: integer
+                            - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                          type: object
-                      type: object
-                  required:
-                    - image
-                  type: object
-                securityContext:
-                  description: PodSecurityContext holds pod-level security attributes
-                    and common container settings. Some fields are also present in container.securityContext.  Field
-                    values of container.securityContext take precedence over field values
-                    of PodSecurityContext.
-                  properties:
-                    fsGroup:
-                      description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
-                      type: string
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container process.
-                        Uses runtime default if unset. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to start
-                        the container if it does. If unset or false, no such validation
-                        will be performed. May also be set in SecurityContext.  If set
-                        in both SecurityContext and PodSecurityContext, the value specified
-                        in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container process.
-                        Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container. Note that this field cannot
-                        be set when spec.os.name is windows.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
-                        Note that this field cannot be set when spec.os.name is windows.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: The seccomp options to use by the containers in this
-                        pod. Note that this field cannot be set when spec.os.name is
-                        windows.
-                      properties:
-                        localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must be
-                            preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
-                          type: string
-                        type:
-                          description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary GID.  If
-                        unspecified, no groups will be added to any container. Note
-                        that this field cannot be set when spec.os.name is windows.
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                    sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used for
-                        the pod. Pods with unsupported sysctls (by the container runtime)
-                        might fail to launch. Note that this field cannot be set when
-                        spec.os.name is windows.
-                      items:
-                        description: Sysctl defines a kernel parameter to be set
-                        properties:
-                          name:
-                            description: Name of a property to set
-                            type: string
-                          value:
-                            description: Value of a property to set
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence. Note
-                        that this field cannot be set when spec.os.name is linux.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named by
-                            the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        hostProcess:
-                          description: HostProcess determines if a container should
-                            be run as a 'Host Process' container. This field is alpha-level
-                            and will only be honored by components that enable the WindowsHostProcessContainers
-                            feature flag. Setting this field without the feature flag
-                            will result in errors when validating the Pod. All of a
-                            Pod's containers must have the same effective HostProcess
-                            value (it is not allowed to have a mix of HostProcess containers
-                            and non-HostProcess containers).  In addition, if HostProcess
-                            is true then HostNetwork must also be set to true.
-                          type: boolean
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
-                  type: object
-                sidecars:
-                  items:
-                    description: Sidecar for each Redis pods
-                    properties:
-                      env:
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must be
-                                a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in the
-                                        specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                      optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of the
-                                        exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select from.  Must
-                                        be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        description: PullPolicy describes a policy for if/when to pull
-                          a container image
-                        type: string
-                      name:
-                        type: string
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of compute
                             resources required. If Requests is omitted for a container,
                             it defaults to Limits if that is explicitly specified,
                             otherwise to an implementation-defined value. More info:
                             https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    required:
-                      - image
-                      - name
-                    type: object
-                  type: array
-                storage:
-                  description: Storage is the inteface to add pvc and pv support in
-                    redis
-                  properties:
-                    volumeClaimTemplate:
-                      description: PersistentVolumeClaim is a user's request for and
-                        claim to a persistent volume
-                      properties:
-                        apiVersion:
-                          description: 'APIVersion defines the versioned schema of this
+                          type: object
+                      type: object
+                  required:
+                  - image
+                  - name
+                  type: object
+                type: array
+              storage:
+                description: Storage is the inteface to add pvc and pv support in
+                  redis
+                properties:
+                  volumeClaimTemplate:
+                    description: PersistentVolumeClaim is a user's request for and
+                      claim to a persistent volume
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
                           representation of an object. Servers should convert recognized
                           schemas to the latest internal value, and may reject unrecognized
                           values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                          type: string
-                        kind:
-                          description: 'Kind is a string value representing the REST
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST
                           resource this object represents. Servers may infer this
                           from the endpoint the client submits requests to. Cannot
                           be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                          type: string
-                        metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                          type: object
-                        spec:
-                          description: 'Spec defines the desired characteristics of
+                        type: string
+                      metadata:
+                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      spec:
+                        description: 'Spec defines the desired characteristics of
                           a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          properties:
-                            accessModes:
-                              description: 'AccessModes contains the desired access
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the desired access
                               modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                              items:
-                                type: string
-                              type: array
-                            dataSource:
-                              description: 'This field can be used to specify either:
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            description: 'This field can be used to specify either:
                               * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                               * An existing PVC (PersistentVolumeClaim) If the provisioner
                               or an external controller can support the specified
@@ -1811,25 +1811,25 @@ spec:
                               contents of the specified data source. If the AnyVolumeDataSource
                               feature gate is enabled, this field will always have
                               the same contents as the DataSourceRef field.'
-                              properties:
-                                apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
-                                  type: string
-                                kind:
-                                  description: Kind is the type of resource being referenced
-                                  type: string
-                                name:
-                                  description: Name is the name of resource being referenced
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                            dataSourceRef:
-                              description: 'Specifies the object from which to populate
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          dataSourceRef:
+                            description: 'Specifies the object from which to populate
                               the volume with data, if a non-empty volume is desired.
                               This may be any local object from a non-empty API group
                               (non core object) or a PersistentVolumeClaim object.
@@ -1850,2409 +1850,260 @@ spec:
                               all values, and generates an error if a disallowed value
                               is   specified. (Alpha) Using this field requires the
                               AnyVolumeDataSource feature gate to be enabled.'
-                              properties:
-                                apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
-                                  type: string
-                                kind:
-                                  description: Kind is the type of resource being referenced
-                                  type: string
-                                name:
-                                  description: Name is the name of resource being referenced
-                                  type: string
-                              required:
-                                - kind
-                                - name
-                              type: object
-                            resources:
-                              description: 'Resources represents the minimum resources
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified,
+                                  the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                          resources:
+                            description: 'Resources represents the minimum resources
                               the volume should have. If RecoverVolumeExpansionFailure
                               feature is enabled users are allowed to specify resource
                               requirements that are lower than previous value but
                               must still be higher than capacity recorded in the status
                               field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                  type: object
-                              type: object
-                            selector:
-                              description: A label query over volumes to consider for
-                                binding.
-                              properties:
-                                matchExpressions:
-                                  description: matchExpressions is a list of label selector
-                                    requirements. The requirements are ANDed.
-                                  items:
-                                    description: A label selector requirement is a selector
-                                      that contains values, a key, and an operator that
-                                      relates the key and values.
-                                    properties:
-                                      key:
-                                        description: key is the label key that the selector
-                                          applies to.
-                                        type: string
-                                      operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are In,
-                                          NotIn, Exists and DoesNotExist.
-                                        type: string
-                                      values:
-                                        description: values is an array of string values.
-                                          If the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator is
-                                          Exists or DoesNotExist, the values array must
-                                          be empty. This array is replaced during a
-                                          strategic merge patch.
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                      - key
-                                      - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  description: matchLabels is a map of {key,value} pairs.
-                                    A single {key,value} in the matchLabels map is equivalent
-                                    to an element of matchExpressions, whose key field
-                                    is "key", the operator is "In", and the values array
-                                    contains only "value". The requirements are ANDed.
-                                  type: object
-                              type: object
-                            storageClassName:
-                              description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                              type: string
-                            volumeMode:
-                              description: volumeMode defines what type of volume is
-                                required by the claim. Value of Filesystem is implied
-                                when not included in claim spec.
-                              type: string
-                            volumeName:
-                              description: VolumeName is the binding reference to the
-                                PersistentVolume backing this claim.
-                              type: string
-                          type: object
-                        status:
-                          description: 'Status represents the current information/status
-                          of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          properties:
-                            accessModes:
-                              description: 'AccessModes contains the actual access modes
-                              the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                              items:
-                                type: string
-                              type: array
-                            allocatedResources:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: The storage resource within AllocatedResources
-                                tracks the capacity allocated to a PVC. It may be larger
-                                than the actual capacity when a volume expansion operation
-                                is requested. For storage quota, the larger value from
-                                allocatedResources and PVC.spec.resources is used. If
-                                allocatedResources is not set, PVC.spec.resources alone
-                                is used for quota calculation. If a volume expansion
-                                capacity request is lowered, allocatedResources is only
-                                lowered if there are no expansion operations in progress
-                                and if the actual volume capacity is equal or lower
-                                than the requested capacity. This is an alpha field
-                                and requires enabling RecoverVolumeExpansionFailure
-                                feature.
-                              type: object
-                            capacity:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: Represents the actual resources of the underlying
-                                volume.
-                              type: object
-                            conditions:
-                              description: Current Condition of persistent volume claim.
-                                If underlying persistent volume is being resized then
-                                the Condition will be set to 'ResizeStarted'.
-                              items:
-                                description: PersistentVolumeClaimCondition contails
-                                  details about state of pvc
-                                properties:
-                                  lastProbeTime:
-                                    description: Last time we probed the condition.
-                                    format: date-time
-                                    type: string
-                                  lastTransitionTime:
-                                    description: Last time the condition transitioned
-                                      from one status to another.
-                                    format: date-time
-                                    type: string
-                                  message:
-                                    description: Human-readable message indicating details
-                                      about last transition.
-                                    type: string
-                                  reason:
-                                    description: Unique, this should be a short, machine
-                                      understandable string that gives the reason for
-                                      condition's last transition. If it reports "ResizeStarted"
-                                      that means the underlying persistent volume is
-                                      being resized.
-                                    type: string
-                                  status:
-                                    type: string
-                                  type:
-                                    description: PersistentVolumeClaimConditionType
-                                      is a valid value of PersistentVolumeClaimCondition.Type
-                                    type: string
-                                required:
-                                  - status
-                                  - type
-                                type: object
-                              type: array
-                            phase:
-                              description: Phase represents the current phase of PersistentVolumeClaim.
-                              type: string
-                            resizeStatus:
-                              description: ResizeStatus stores status of resize operation.
-                                ResizeStatus is not set by default but when expansion
-                                is complete resizeStatus is set to empty string by resize
-                                controller or kubelet. This is an alpha field and requires
-                                enabling RecoverVolumeExpansionFailure feature.
-                              type: string
-                          type: object
-                      type: object
-                  type: object
-                tolerations:
-                  items:
-                    description: The pod this Toleration is attached to tolerates any
-                      taint that matches the triple <key,value,effect> using the matching
-                      operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match all
-                          values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to Equal.
-                          Exists is equivalent to wildcard for value, so that a pod
-                          can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default, it
-                          is not set, which means tolerate the taint forever (do not
-                          evict). Zero and negative values will be treated as 0 (evict
-                          immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-              required:
-                - kubernetesConfig
-              type: object
-            status:
-              description: RedisStatus defines the observed state of Redis
-              properties:
-                redis:
-                  description: RedisSpec defines the desired state of Redis
-                  properties:
-                    TLS:
-                      description: TLS Configuration for redis instances
-                      properties:
-                        ca:
-                          type: string
-                        cert:
-                          type: string
-                        key:
-                          type: string
-                        secret:
-                          description: Reference to secret which contains the certificates
-                          properties:
-                            defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                              format: int32
-                              type: integer
-                            items:
-                              description: If unspecified, each key-value pair in the
-                                Data field of the referenced Secret will be projected
-                                into the volume as a file whose name is the key and
-                                content is the value. If specified, the listed keys
-                                will be projected into the specified paths, and unlisted
-                                keys will not be present. If a key is specified which
-                                is not present in the Secret, the volume setup will
-                                error unless it is marked optional. Paths must be relative
-                                and may not contain the '..' path or start with '..'.
-                              items:
-                                description: Maps a string key to a path within a volume.
-                                properties:
-                                  key:
-                                    description: The key to project.
-                                    type: string
-                                  mode:
-                                    description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    description: The relative path of the file to map
-                                      the key to. May not be an absolute path. May not
-                                      contain the path element '..'. May not start with
-                                      the string '..'.
-                                    type: string
-                                required:
-                                  - key
-                                  - path
-                                type: object
-                              type: array
-                            optional:
-                              description: Specify whether the Secret or its keys must
-                                be defined
-                              type: boolean
-                            secretName:
-                              description: 'Name of the secret in the pod''s namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                              type: string
-                          type: object
-                      required:
-                        - secret
-                      type: object
-                    affinity:
-                      description: Affinity is a group of affinity scheduling rules.
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: The label key that the selector
-                                                applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of namespaces
-                                          that the term applies to. The term is applied
-                                          to the union of the namespaces selected by
-                                          this field and the ones listed in the namespaces
-                                          field. null selector and null or empty namespaces
-                                          list means "this pod's namespace". An empty
-                                          selector ({}) matches all namespaces. This
-                                          field is beta-level and is only honored when
-                                          PodAffinityNamespaceSelector feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static list
-                                          of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces
-                                          listed in this field and the ones selected
-                                          by namespaceSelector. null or empty namespaces
-                                          list and null namespaceSelector means "this
-                                          pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaceSelector:
-                                        description: A label query over the set of namespaces
-                                          that the term applies to. The term is applied
-                                          to the union of the namespaces selected by
-                                          this field and the ones listed in the namespaces
-                                          field. null selector and null or empty namespaces
-                                          list means "this pod's namespace". An empty
-                                          selector ({}) matches all namespaces. This
-                                          field is beta-level and is only honored when
-                                          PodAffinityNamespaceSelector feature is enabled.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies a static list
-                                          of namespace names that the term applies to.
-                                          The term is applied to the union of the namespaces
-                                          listed in this field and the ones selected
-                                          by namespaceSelector. null or empty namespaces
-                                          list and null namespaceSelector means "this
-                                          pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    kubernetesConfig:
-                      description: KubernetesConfig will be the JSON struct for Basic
-                        Redis Config
-                      properties:
-                        image:
-                          type: string
-                        imagePullPolicy:
-                          description: PullPolicy describes a policy for if/when to
-                            pull a container image
-                          type: string
-                        imagePullSecrets:
-                          items:
-                            description: LocalObjectReference contains enough information
-                              to let you locate the referenced object inside the same
-                              namespace.
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                                type: string
-                            type: object
-                          type: array
-                        redisSecret:
-                          description: ExistingPasswordSecret is the struct to access
-                            the existing secret
-                          properties:
-                            key:
-                              type: string
-                            name:
-                              type: string
-                          type: object
-                        resources:
-                          description: ResourceRequirements describes the compute resource
-                            requirements.
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                          type: object
-                      required:
-                        - image
-                      type: object
-                    livenessProbe:
-                      description: Probe describes a health check to be performed against
-                        a container to determine whether it is alive or ready to receive
-                        traffic.
-                      properties:
-                        exec:
-                          description: Exec specifies the action to take.
-                          properties:
-                            command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          description: Minimum consecutive failures for the probe to
-                            be considered failed after having succeeded. Defaults to
-                            3. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        grpc:
-                          description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
-                            feature gate.
-                          properties:
-                            port:
-                              description: Port number of the gRPC service. Number must
-                                be in the range 1 to 65535.
-                              format: int32
-                              type: integer
-                            service:
-                              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        httpGet:
-                          description: HTTPGet specifies the http request to perform.
-                          properties:
-                            host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
-                              type: string
-                            httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
-                              items:
-                                description: HTTPHeader describes a custom header to
-                                  be used in HTTP probes
-                                properties:
-                                  name:
-                                    description: The header field name
-                                    type: string
-                                  value:
-                                    description: The header field value
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              description: Path to access on the HTTP server.
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                            scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          description: Minimum consecutive successes for the probe to
-                            be considered successful after having failed. Defaults to
-                            1. Must be 1 for liveness and startup. Minimum value is
-                            1.
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
-                          properties:
-                            host:
-                              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs to
-                            terminate gracefully upon probe failure. The grace period
-                            is the duration in seconds after the processes running in
-                            the pod are sent a termination signal and the time when
-                            the processes are forcibly halted with a kill signal. Set
-                            this value longer than the expected cleanup time for your
-                            process. If this value is nil, the pod's terminationGracePeriodSeconds
-                            will be used. Otherwise, this value overrides the value
-                            provided by the pod spec. Value must be non-negative integer.
-                            The value zero indicates stop immediately via the kill signal
-                            (no opportunity to shut down). This is a beta field and
-                            requires enabling ProbeTerminationGracePeriod feature gate.
-                            Minimum value is 1. spec.terminationGracePeriodSeconds is
-                            used if unset.
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      type: object
-                    priorityClassName:
-                      type: string
-                    readinessProbe:
-                      description: Probe describes a health check to be performed against
-                        a container to determine whether it is alive or ready to receive
-                        traffic.
-                      properties:
-                        exec:
-                          description: Exec specifies the action to take.
-                          properties:
-                            command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        failureThreshold:
-                          description: Minimum consecutive failures for the probe to
-                            be considered failed after having succeeded. Defaults to
-                            3. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        grpc:
-                          description: GRPC specifies an action involving a GRPC port.
-                            This is an alpha field and requires enabling GRPCContainerProbe
-                            feature gate.
-                          properties:
-                            port:
-                              description: Port number of the gRPC service. Number must
-                                be in the range 1 to 65535.
-                              format: int32
-                              type: integer
-                            service:
-                              description: "Service is the name of the service to place
-                              in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                              \n If this is not specified, the default behavior is
-                              defined by gRPC."
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        httpGet:
-                          description: HTTPGet specifies the http request to perform.
-                          properties:
-                            host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
-                              type: string
-                            httpHeaders:
-                              description: Custom headers to set in the request. HTTP
-                                allows repeated headers.
-                              items:
-                                description: HTTPHeader describes a custom header to
-                                  be used in HTTP probes
-                                properties:
-                                  name:
-                                    description: The header field name
-                                    type: string
-                                  value:
-                                    description: The header field value
-                                    type: string
-                                required:
-                                  - name
-                                  - value
-                                type: object
-                              type: array
-                            path:
-                              description: Path to access on the HTTP server.
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                            scheme:
-                              description: Scheme to use for connecting to the host.
-                                Defaults to HTTP.
-                              type: string
-                          required:
-                            - port
-                          type: object
-                        initialDelaySeconds:
-                          description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                        periodSeconds:
-                          description: How often (in seconds) to perform the probe.
-                            Default to 10 seconds. Minimum value is 1.
-                          format: int32
-                          type: integer
-                        successThreshold:
-                          description: Minimum consecutive successes for the probe to
-                            be considered successful after having failed. Defaults to
-                            1. Must be 1 for liveness and startup. Minimum value is
-                            1.
-                          format: int32
-                          type: integer
-                        tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP
-                            port.
-                          properties:
-                            host:
-                              description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                              type: string
-                            port:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
-                              x-kubernetes-int-or-string: true
-                          required:
-                            - port
-                          type: object
-                        terminationGracePeriodSeconds:
-                          description: Optional duration in seconds the pod needs to
-                            terminate gracefully upon probe failure. The grace period
-                            is the duration in seconds after the processes running in
-                            the pod are sent a termination signal and the time when
-                            the processes are forcibly halted with a kill signal. Set
-                            this value longer than the expected cleanup time for your
-                            process. If this value is nil, the pod's terminationGracePeriodSeconds
-                            will be used. Otherwise, this value overrides the value
-                            provided by the pod spec. Value must be non-negative integer.
-                            The value zero indicates stop immediately via the kill signal
-                            (no opportunity to shut down). This is a beta field and
-                            requires enabling ProbeTerminationGracePeriod feature gate.
-                            Minimum value is 1. spec.terminationGracePeriodSeconds is
-                            used if unset.
-                          format: int64
-                          type: integer
-                        timeoutSeconds:
-                          description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          format: int32
-                          type: integer
-                      type: object
-                    redisConfig:
-                      description: RedisConfig defines the external configuration of
-                        Redis
-                      properties:
-                        additionalRedisConfig:
-                          type: string
-                      type: object
-                    redisExporter:
-                      description: RedisExporter interface will have the information
-                        for redis exporter related stuff
-                      properties:
-                        enabled:
-                          type: boolean
-                        env:
-                          items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment variables
-                                in the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. Double $$ are
-                                reduced to a single $, which allows for escaping the
-                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
-                                the string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether the
-                                variable exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or its
-                                          key must be defined
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        image:
-                          type: string
-                        imagePullPolicy:
-                          description: PullPolicy describes a policy for if/when to
-                            pull a container image
-                          type: string
-                        resources:
-                          description: ResourceRequirements describes the compute resource
-                            requirements.
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                          type: object
-                      required:
-                        - image
-                      type: object
-                    securityContext:
-                      description: PodSecurityContext holds pod-level security attributes
-                        and common container settings. Some fields are also present
-                        in container.securityContext.  Field values of container.securityContext
-                        take precedence over field values of PodSecurityContext.
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume. Note that this field cannot be
-                          set when spec.os.name is windows."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used. Note that
-                          this field cannot be set when spec.os.name is windows.'
-                          type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container. Note that this field
-                            cannot be set when spec.os.name is windows.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
-                            Note that this field cannot be set when spec.os.name is
-                            windows.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container. Note that this field cannot be set when
-                            spec.os.name is windows.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod. Note that this field cannot be set when spec.os.name
-                            is windows.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
-                            Note that this field cannot be set when spec.os.name is
-                            windows.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch. Note that this field cannot
-                            be set when spec.os.name is windows.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence. Note that this field cannot be set when
-                            spec.os.name is linux.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            hostProcess:
-                              description: HostProcess determines if a container should
-                                be run as a 'Host Process' container. This field is
-                                alpha-level and will only be honored by components that
-                                enable the WindowsHostProcessContainers feature flag.
-                                Setting this field without the feature flag will result
-                                in errors when validating the Pod. All of a Pod's containers
-                                must have the same effective HostProcess value (it is
-                                not allowed to have a mix of HostProcess containers
-                                and non-HostProcess containers).  In addition, if HostProcess
-                                is true then HostNetwork must also be set to true.
-                              type: boolean
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    sidecars:
-                      items:
-                        description: Sidecar for each Redis pods
-                        properties:
-                          env:
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previously defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  Double $$ are reduced to a single $, which allows
-                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                  will produce the string literal "$(VAR_NAME)". Escaped
-                                  references will never be expanded, regardless of
-                                  whether the variable exists or not. Defaults to
-                                  "".'
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                    fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select in
-                                            the specified API version.
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                          volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          description: Specifies the output format of
-                                            the exposed resources, defaults to "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret or
-                                            its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                  type: object
-                              required:
-                                - name
-                              type: object
-                            type: array
-                          image:
-                            type: string
-                          imagePullPolicy:
-                            description: PullPolicy describes a policy for if/when to
-                              pull a container image
-                            type: string
-                          name:
-                            type: string
-                          resources:
-                            description: ResourceRequirements describes the compute
-                              resource requirements.
                             properties:
                               limits:
                                 additionalProperties:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                               requests:
                                 additionalProperties:
                                   anyOf:
-                                    - type: integer
-                                    - type: string
+                                  - type: integer
+                                  - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                 type: object
                             type: object
-                        required:
-                          - image
-                          - name
-                        type: object
-                      type: array
-                    storage:
-                      description: Storage is the inteface to add pvc and pv support
-                        in redis
-                      properties:
-                        volumeClaimTemplate:
-                          description: PersistentVolumeClaim is a user's request for
-                            and claim to a persistent volume
-                          properties:
-                            apiVersion:
-                              description: 'APIVersion defines the versioned schema
-                              of this representation of an object. Servers should
-                              convert recognized schemas to the latest internal value,
-                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                              type: string
-                            kind:
-                              description: 'Kind is a string value representing the
-                              REST resource this object represents. Servers may infer
-                              this from the endpoint the client submits requests to.
-                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                              type: string
-                            metadata:
-                              description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                              type: object
-                            spec:
-                              description: 'Spec defines the desired characteristics
-                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                              properties:
-                                accessModes:
-                                  description: 'AccessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                  items:
-                                    type: string
-                                  type: array
-                                dataSource:
-                                  description: 'This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                  * An existing PVC (PersistentVolumeClaim) If the
-                                  provisioner or an external controller can support
-                                  the specified data source, it will create a new
-                                  volume based on the contents of the specified data
-                                  source. If the AnyVolumeDataSource feature gate
-                                  is enabled, this field will always have the same
-                                  contents as the DataSourceRef field.'
+                          selector:
+                            description: A label query over volumes to consider for
+                              binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
                                   properties:
-                                    apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is
-                                        required.
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
                                       type: string
-                                    kind:
-                                      description: Kind is the type of resource being
-                                        referenced
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
                                       type: string
-                                    name:
-                                      description: Name is the name of resource being
-                                        referenced
-                                      type: string
-                                  required:
-                                    - kind
-                                    - name
-                                  type: object
-                                dataSourceRef:
-                                  description: 'Specifies the object from which to populate
-                                  the volume with data, if a non-empty volume is desired.
-                                  This may be any local object from a non-empty API
-                                  group (non core object) or a PersistentVolumeClaim
-                                  object. When this field is specified, volume binding
-                                  will only succeed if the type of the specified object
-                                  matches some installed volume populator or dynamic
-                                  provisioner. This field will replace the functionality
-                                  of the DataSource field and as such if both fields
-                                  are non-empty, they must have the same value. For
-                                  backwards compatibility, both fields (DataSource
-                                  and DataSourceRef) will be set to the same value
-                                  automatically if one of them is empty and the other
-                                  is non-empty. There are two important differences
-                                  between DataSource and DataSourceRef: * While DataSource
-                                  only allows two specific types of objects, DataSourceRef   allows
-                                  any non-core object, as well as PersistentVolumeClaim
-                                  objects. * While DataSource ignores disallowed values
-                                  (dropping them), DataSourceRef   preserves all values,
-                                  and generates an error if a disallowed value is   specified.
-                                  (Alpha) Using this field requires the AnyVolumeDataSource
-                                  feature gate to be enabled.'
-                                  properties:
-                                    apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API group.
-                                        For any other third-party types, APIGroup is
-                                        required.
-                                      type: string
-                                    kind:
-                                      description: Kind is the type of resource being
-                                        referenced
-                                      type: string
-                                    name:
-                                      description: Name is the name of resource being
-                                        referenced
-                                      type: string
-                                  required:
-                                    - kind
-                                    - name
-                                  type: object
-                                resources:
-                                  description: 'Resources represents the minimum resources
-                                  the volume should have. If RecoverVolumeExpansionFailure
-                                  feature is enabled users are allowed to specify
-                                  resource requirements that are lower than previous
-                                  value but must still be higher than capacity recorded
-                                  in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                      type: object
-                                  type: object
-                                selector:
-                                  description: A label query over volumes to consider
-                                    for binding.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
                                       items:
-                                        description: A label selector requirement is
-                                          a selector that contains values, a key, and
-                                          an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that the
-                                              selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty. If
-                                              the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This array
-                                              is replaced during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                          - key
-                                          - operator
-                                        type: object
+                                        type: string
                                       type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is "In",
-                                        and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
-                                storageClassName:
-                                  description: 'Name of the StorageClass required by
-                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                type: array
+                              matchLabels:
+                                additionalProperties:
                                   type: string
-                                volumeMode:
-                                  description: volumeMode defines what type of volume
-                                    is required by the claim. Value of Filesystem is
-                                    implied when not included in claim spec.
-                                  type: string
-                                volumeName:
-                                  description: VolumeName is the binding reference to
-                                    the PersistentVolume backing this claim.
-                                  type: string
-                              type: object
-                            status:
-                              description: 'Status represents the current information/status
-                              of a persistent volume claim. Read-only. More info:
-                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                              properties:
-                                accessModes:
-                                  description: 'AccessModes contains the actual access
-                                  modes the volume backing the PVC has. More info:
-                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                  items:
-                                    type: string
-                                  type: array
-                                allocatedResources:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: The storage resource within AllocatedResources
-                                    tracks the capacity allocated to a PVC. It may be
-                                    larger than the actual capacity when a volume expansion
-                                    operation is requested. For storage quota, the larger
-                                    value from allocatedResources and PVC.spec.resources
-                                    is used. If allocatedResources is not set, PVC.spec.resources
-                                    alone is used for quota calculation. If a volume
-                                    expansion capacity request is lowered, allocatedResources
-                                    is only lowered if there are no expansion operations
-                                    in progress and if the actual volume capacity is
-                                    equal or lower than the requested capacity. This
-                                    is an alpha field and requires enabling RecoverVolumeExpansionFailure
-                                    feature.
-                                  type: object
-                                capacity:
-                                  additionalProperties:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  description: Represents the actual resources of the
-                                    underlying volume.
-                                  type: object
-                                conditions:
-                                  description: Current Condition of persistent volume
-                                    claim. If underlying persistent volume is being
-                                    resized then the Condition will be set to 'ResizeStarted'.
-                                  items:
-                                    description: PersistentVolumeClaimCondition contails
-                                      details about state of pvc
-                                    properties:
-                                      lastProbeTime:
-                                        description: Last time we probed the condition.
-                                        format: date-time
-                                        type: string
-                                      lastTransitionTime:
-                                        description: Last time the condition transitioned
-                                          from one status to another.
-                                        format: date-time
-                                        type: string
-                                      message:
-                                        description: Human-readable message indicating
-                                          details about last transition.
-                                        type: string
-                                      reason:
-                                        description: Unique, this should be a short,
-                                          machine understandable string that gives the
-                                          reason for condition's last transition. If
-                                          it reports "ResizeStarted" that means the
-                                          underlying persistent volume is being resized.
-                                        type: string
-                                      status:
-                                        type: string
-                                      type:
-                                        description: PersistentVolumeClaimConditionType
-                                          is a valid value of PersistentVolumeClaimCondition.Type
-                                        type: string
-                                    required:
-                                      - status
-                                      - type
-                                    type: object
-                                  type: array
-                                phase:
-                                  description: Phase represents the current phase of
-                                    PersistentVolumeClaim.
-                                  type: string
-                                resizeStatus:
-                                  description: ResizeStatus stores status of resize
-                                    operation. ResizeStatus is not set by default but
-                                    when expansion is complete resizeStatus is set to
-                                    empty string by resize controller or kubelet. This
-                                    is an alpha field and requires enabling RecoverVolumeExpansionFailure
-                                    feature.
-                                  type: string
-                              type: object
-                          type: object
-                      type: object
-                    tolerations:
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          storageClassName:
+                            description: 'Name of the StorageClass required by the
+                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                             type: string
-                          key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
+                          volumeMode:
+                            description: volumeMode defines what type of volume is
+                              required by the claim. Value of Filesystem is implied
+                              when not included in claim spec.
                             type: string
-                          operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
+                          volumeName:
+                            description: VolumeName is the binding reference to the
+                              PersistentVolume backing this claim.
                             type: string
                         type: object
-                      type: array
-                  required:
-                    - kubernetesConfig
+                      status:
+                        description: 'Status represents the current information/status
+                          of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the actual access modes
+                              the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          allocatedResources:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: The storage resource within AllocatedResources
+                              tracks the capacity allocated to a PVC. It may be larger
+                              than the actual capacity when a volume expansion operation
+                              is requested. For storage quota, the larger value from
+                              allocatedResources and PVC.spec.resources is used. If
+                              allocatedResources is not set, PVC.spec.resources alone
+                              is used for quota calculation. If a volume expansion
+                              capacity request is lowered, allocatedResources is only
+                              lowered if there are no expansion operations in progress
+                              and if the actual volume capacity is equal or lower
+                              than the requested capacity. This is an alpha field
+                              and requires enabling RecoverVolumeExpansionFailure
+                              feature.
+                            type: object
+                          capacity:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: Represents the actual resources of the underlying
+                              volume.
+                            type: object
+                          conditions:
+                            description: Current Condition of persistent volume claim.
+                              If underlying persistent volume is being resized then
+                              the Condition will be set to 'ResizeStarted'.
+                            items:
+                              description: PersistentVolumeClaimCondition contails
+                                details about state of pvc
+                              properties:
+                                lastProbeTime:
+                                  description: Last time we probed the condition.
+                                  format: date-time
+                                  type: string
+                                lastTransitionTime:
+                                  description: Last time the condition transitioned
+                                    from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Human-readable message indicating details
+                                    about last transition.
+                                  type: string
+                                reason:
+                                  description: Unique, this should be a short, machine
+                                    understandable string that gives the reason for
+                                    condition's last transition. If it reports "ResizeStarted"
+                                    that means the underlying persistent volume is
+                                    being resized.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: PersistentVolumeClaimConditionType
+                                    is a valid value of PersistentVolumeClaimCondition.Type
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          phase:
+                            description: Phase represents the current phase of PersistentVolumeClaim.
+                            type: string
+                          resizeStatus:
+                            description: ResizeStatus stores status of resize operation.
+                              ResizeStatus is not set by default but when expansion
+                              is complete resizeStatus is set to empty string by resize
+                              controller or kubelet. This is an alpha field and requires
+                              enabling RecoverVolumeExpansionFailure feature.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              tolerations:
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
                   type: object
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+            required:
+            - kubernetesConfig
+            type: object
+          status:
+            description: RedisStatus defines the observed state of Redis
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
/close #18 
/close #19
/close https://github.com/OT-CONTAINER-KIT/redis-operator/issues/241

I have replaced CRDs with the results generated by Kustomize produced from https://github.com/OT-CONTAINER-KIT/redis-operator/tree/v0.10.0/config/crd 

Current CRDs defenitions in master are broken (contains unresolved git conflicts)