### PR TITLE
Adjust ClusterRole to allow PVC interaction

### DIFF
--- a/charts/mongodb-cluster/Chart.yaml
+++ b/charts/mongodb-cluster/Chart.yaml
@@ -7,8 +7,8 @@ maintainers:
 name: mongodb-cluster
 sources:
   - https://github.com/ot-container-kit/mongodb-operator
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 home: https://github.com/ot-container-kit/mongodb-operator
 keywords:
 - operator

--- a/charts/mongodb-cluster/templates/configmap.yaml
+++ b/charts/mongodb-cluster/templates/configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.mongoDBConfiguration }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-additional-config
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: database
+data:
+  mongo.yaml: |
+    {{ .Values.mongoDBMonitoring.resources | indent 4 }}
+{{- end }}

--- a/charts/mongodb-cluster/templates/mongodb-cluster.yaml
+++ b/charts/mongodb-cluster/templates/mongodb-cluster.yaml
@@ -41,6 +41,9 @@ spec:
     storageSize: {{ .Values.storage.storageSize }}
     storageClass: {{ .Values.storage.storageClass }}
 {{- end }}
+{{- if .Values.mongoDBConfiguration }}
+  mongoDBAdditionalConfig: {{ .Release.Name }}-additional-config
+{{- end }}
   mongoDBSecurity:
     mongoDBAdminUser: admin
     secretRef:

--- a/charts/mongodb-cluster/values.yaml
+++ b/charts/mongodb-cluster/values.yaml
@@ -55,6 +55,11 @@ mongoDBMonitoring:
     #   cpu: 100m
     #   memory: 128Mi
 
+#mongoDBConfiguration: |-
+#  net:
+#    bindIp: 0.0.0.0
+#    port: 27017
+
 serviceMonitor:
   enabled: false
   interval: 30s

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -7,8 +7,8 @@ maintainers:
 name: mongodb
 sources:
   - https://github.com/ot-container-kit/mongodb-operator
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 home: https://github.com/ot-container-kit/mongodb-operator
 keywords:
 - operator

--- a/charts/mongodb/templates/configmap.yaml
+++ b/charts/mongodb/templates/configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.mongoDBConfiguration }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-additional-config
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: database
+data:
+  mongo.yaml: |
+    {{ .Values.mongoDBMonitoring.resources | indent 4 }}
+{{- end }}

--- a/charts/mongodb/templates/mongodb.yaml
+++ b/charts/mongodb/templates/mongodb.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   kubernetesConfig:
     image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+    securityContext:
+      fsGroup: 1001
     imagePullPolicy: {{ .Values.image.imagePullPolicy }}
 {{- if .Values.image.pullSecret }}
     imagePullSecret: {{ .Values.image.pullSecret }}
@@ -45,6 +47,9 @@ spec:
     secretRef:
       name: {{ .Release.Name }}-secret
       key: password
+{{- if .Values.mongoDBConfiguration }}
+  mongoDBAdditionalConfig: {{ .Release.Name }}-additional-config
+{{- end }}
 {{- if .Values.mongoDBMonitoring.enabled }}
   mongoDBMonitoring:
     enableExporter: {{ .Values.mongoDBMonitoring.enabled }}

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   name: quay.io/opstree/mongo
-  tag: v5.0
+  tag: v5.0.6
   imagePullPolicy: IfNotPresent
   # pullSecret: regcred
 
@@ -9,6 +9,9 @@ nodeSelector: {}
 #  memory: high
 
 #priorityClassName: "-"
+
+securityContext:
+  fsGroup: 1001
 
 affinity: {}
   # nodeAffinity:
@@ -52,6 +55,11 @@ mongoDBMonitoring:
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
+
+#mongoDBConfiguration: |-
+#  net:
+#    bindIp: 0.0.0.0
+#    port: 27017
 
 serviceMonitor:
   enabled: false

--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: redis-operator
 sources:
   - https://github.com/OT-CONTAINER-KIT/redis-operator
-version: 0.10.2
+version: 0.10.3
 home: https://github.com/OT-CONTAINER-KIT/redis-operator
 icon: https://github.com/OT-CONTAINER-KIT/redis-operator/raw/master/static/redis-operator-logo.svg
 keywords:

--- a/charts/redis-operator/templates/role.yaml
+++ b/charts/redis-operator/templates/role.yaml
@@ -51,6 +51,7 @@ rules:
   - services
   - configmaps
   - events
+  - persistentvolumeclaims
   verbs:
   - create
   - delete


### PR DESCRIPTION
Signed-off-by: Michael Beasley <michael.beasley@alvaria.com>

Resolves:
```shell
 /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227
1.6492677212931046e+09  ERROR   controller.redis        Reconciler error        {"reconciler group": "redis.redis.opstreelabs.in", "reconciler kind": "Redis", "name": "redis-test", "namespace": "redis-test", "error": "persistentvolumeclaims \"redis-test-redis-test-0\" is forbidden: User \"system:serviceaccount:redis-operator:redis-operator\" cannot delete resource \"persistentvolumeclaims\" in API group \"\" in the namespace \"redis-test\""}
```

That error can be replicated by using the `quay.io/opstree/redis-operator:0.10.0` container image.