### PR TITLE
Add PersistentVolumeClaims to ClusterRole

### DIFF
--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: redis-operator
 sources:
   - https://github.com/OT-CONTAINER-KIT/redis-operator
-version: 0.10.2
+version: 0.10.3
 home: https://github.com/OT-CONTAINER-KIT/redis-operator
 icon: https://github.com/OT-CONTAINER-KIT/redis-operator/raw/master/static/redis-operator-logo.svg
 keywords:

--- a/charts/redis-operator/templates/role.yaml
+++ b/charts/redis-operator/templates/role.yaml
@@ -51,6 +51,7 @@ rules:
   - services
   - configmaps
   - events
+  - persistentvolumeclaims
   verbs:
   - create
   - delete


### PR DESCRIPTION
Signed-off-by: Michael Beasley <michael.beasley@alvaria.com>


Resolves:
```
 /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227
1.6492677212931046e+09  ERROR   controller.redis        Reconciler error        {"reconciler group": "redis.redis.opstreelabs.in", "reconciler kind": "Redis", "name": "redis-test", "namespace": "redis-test", "error": "persistentvolumeclaims \"redis-test-redis-test-0\" is forbidden: User \"system:serviceaccount:redis-operator:redis-operator\" cannot delete resource \"persistentvolumeclaims\" in API group \"\" in the namespace \"redis-test\""}
```

That error can be replicated by using the `quay.io/opstree/redis-operator:0.10.0` container image.