### PR TITLE
Fix affinity indentation of redis-cluster helm chart

### DIFF
--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -14,8 +14,7 @@ spec:
   clusterSize: {{ .Values.redisCluster.clusterSize }}
   redisLeader:
 {{- if .Values.redisCluster.leader.affinity }}
-    affinity:
-  {{ toYaml .Values.redisCluster.leader.affinity | indent 6 }}
+    affinity: {{ toYaml .Values.redisCluster.leader.affinity | nindent 6 }}
 {{- end }}
     replicas: {{ .Values.redisCluster.leader.replicas }}
 {{- if eq .Values.externalConfig.enabled true }}
@@ -24,8 +23,7 @@ spec:
 {{- end }}
   redisFollower:
 {{- if .Values.redisCluster.follower.affinity }}
-    affinity:
-  {{ toYaml .Values.redisCluster.follower.affinity | indent 6 }}
+    affinity: {{ toYaml .Values.redisCluster.follower.affinity | nindent 6 }}
 {{- end }}
     replicas: {{ .Values.redisCluster.follower.replicas }}
 {{- if eq .Values.externalConfig.enabled true }}


### PR DESCRIPTION
This change aims to fix the indentation of the RedisCluster template under `spec.redisLeader.affinity` and `spec.redisFollower.affinity`.

The issue for the affinity indentation becomes visible by running the command
`helm template ./redis-cluster -f ./values.yaml`

values.yaml:
```yaml
redisCluster:
  leader:
    affinity:
      podAntiAffinity:
        preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  app: redis-cluster-leader
                  role: leader
              topologyKey: kubernetes.io/hostname
            weight: 100
  follower:
    replicas: 3
    affinity:
      podAntiAffinity:
        preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchLabels:
                  app: redis-cluster-follower
                  role: follower
              topologyKey: kubernetes.io/hostname
            weight: 100
```

Command output before:
```yaml
---
# Source: redis-cluster/templates/redis-cluster.yaml
apiVersion: redis.redis.opstreelabs.in/v1beta1
kind: RedisCluster
metadata:
  name: RELEASE-NAME
  labels:
    app.kubernetes.io/name: RELEASE-NAME
    helm.sh/chart: redis-cluster-0.10.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: 0.10.0
    app.kubernetes.io/component: middleware
spec:
  clusterSize: 3
  redisLeader:
    affinity:
        podAntiAffinity:
        preferredDuringSchedulingIgnoredDuringExecution:
        - podAffinityTerm:
            labelSelector:
              matchLabels:
                app: redis-cluster-leader
                role: leader
            topologyKey: kubernetes.io/hostname
          weight: 100
    replicas: 3
  redisFollower:
    affinity:
        podAntiAffinity:
        preferredDuringSchedulingIgnoredDuringExecution:
        - podAffinityTerm:
            labelSelector:
              matchLabels:
                app: redis-cluster-follower
                role: follower
            topologyKey: kubernetes.io/hostname
          weight: 100
    replicas: 3
  redisExporter:
    enabled: true
    image: "quay.io/opstree/redis-exporter:1.0"
    imagePullPolicy: "IfNotPresent"
    resources:
      {}
  kubernetesConfig:
    image: "quay.io/opstree/redis:v6.2.5"
    imagePullPolicy: "IfNotPresent"
    resources:
      {}
  storage:
    volumeClaimTemplate:
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 1Gi
```

Command output afterwards:
```yaml
---
# Source: redis-cluster/templates/redis-cluster.yaml
apiVersion: redis.redis.opstreelabs.in/v1beta1
kind: RedisCluster
metadata:
  name: RELEASE-NAME
  labels:
    app.kubernetes.io/name: RELEASE-NAME
    helm.sh/chart: redis-cluster-0.10.0
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: 0.10.0
    app.kubernetes.io/component: middleware
spec:
  clusterSize: 3
  redisLeader:
    affinity:
      podAntiAffinity:
        preferredDuringSchedulingIgnoredDuringExecution:
        - podAffinityTerm:
            labelSelector:
              matchLabels:
                app: redis-cluster-leader
                role: leader
            topologyKey: kubernetes.io/hostname
          weight: 100
    replicas: 3
  redisFollower:
    affinity:
      podAntiAffinity:
        preferredDuringSchedulingIgnoredDuringExecution:
        - podAffinityTerm:
            labelSelector:
              matchLabels:
                app: redis-cluster-follower
                role: follower
            topologyKey: kubernetes.io/hostname
          weight: 100
    replicas: 3
  redisExporter:
    enabled: true
    image: "quay.io/opstree/redis-exporter:1.0"
    imagePullPolicy: "IfNotPresent"
    resources:
      {}
  kubernetesConfig:
    image: "quay.io/opstree/redis:v6.2.5"
    imagePullPolicy: "IfNotPresent"
    resources:
      {}
  storage:
    volumeClaimTemplate:
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 1Gi
```