### PR TITLE
Adding optional name override for standalone service

### DIFF
--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -37,6 +37,7 @@ $ helm delete <my-release> --namespace <namespace>
 |`redisStandalone.imagePullPolicy` | IfNotPresent | Image Pull Policy of the redis image |
 |`redisStandalone.serviceType` | ClusterIP | Kubernetes service type for Redis |
 |`redisStandalone.resources` | {} | Request and limits for redis statefulset |
+|`redisStandalone.nameOverride` | string | Overriding name for service |
 |`externalService.enabled`| false | If redis service needs to be exposed using LoadBalancer or NodePort |
 |`externalService.annotations`| {} | Kubernetes service related annotations |
 |`externalService.serviceType` | NodePort | Kubernetes service type for exposing service, values - ClusterIP, NodePort, and LoadBalancer |

--- a/charts/redis/templates/extra-config.yaml
+++ b/charts/redis/templates/extra-config.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-ext-config
+  name: {{ .Values.redisStandalone.nameOverride | default .Release.Name }}-ext-config
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -2,7 +2,7 @@
 apiVersion: redis.redis.opstreelabs.in/v1beta1
 kind: Redis
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Values.redisStandalone.nameOverride | default .Release.Name }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-external-service
+  name: {{ .Values.redisStandalone.nameOverride | default .Release.Name }}-external-service
 {{- if .Values.externalService.annotations }}
   annotations:
 {{ toYaml .Values.externalService.annotations | indent 4 }}
@@ -18,7 +18,7 @@ metadata:
 spec:
   type: {{ .Values.externalService.serviceType }}
   selector:
-    app: {{ .Release.Name }}
+    app: {{ .Values.redisStandalone.nameOverride | default .Release.Name }}
     redis_setup_type: standalone
     role: standalone
   ports:

--- a/charts/redis/templates/servicemonitor.yaml
+++ b/charts/redis/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Release.Name }}-prometheus-monitoring
+  name: {{ .Values.redisStandalone.nameOverride | default .Release.Name }}-prometheus-monitoring
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
Hi,

This is my first PR for any open source component so bear with me.

This Pr is for allowing user of this chart to define a name for redis standalone. 
We have a problem with using the redis standalone as a helm dependency in our project.

This will allow the redis standalone to override the value and overcome the problem where we have service using this as helm dependency and this is overriding the dependent service ".Release.Name" svc component becouse they both would have the same name otherwise.

Example:

In chart.yaml of dependent service:

name: my-service
dependencies:
  - name: redis
    version: "0.9.0"


So in this case if my-service has similary named svc definition then redis standalone would override this with its one service named like "my-service" becous it would use the ".Release.Name" from dependent helm chat, in this case "my-service"
   

