### PR TITLE
fix(charts/redis-cluster): pdb misconfiguration issue

### DIFF
--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: redis-cluster
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.12.1
+version: 0.12.2
 appVersion: "0.12.0"
 home: https://github.com/ot-container-kit/redis-operator
 keywords:

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -31,8 +31,12 @@ spec:
 {{- if eq .Values.pdb.enabled true }}
     pdb:
       enabled: {{ .Values.pdb.enabled }}
+      {{- if .Values.pdb.maxUnavailable }}
       maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+      {{- end  }}
+      {{- if .Values.pdb.minAvailable }}
       minAvailable: {{ .Values.pdb.minAvailable }}
+      {{- end  }}
 {{- end }}
   redisFollower:
 {{- if .Values.redisCluster.follower.affinity }}
@@ -46,8 +50,12 @@ spec:
 {{- if eq .Values.pdb.enabled true }}
     pdb:
       enabled: {{ .Values.pdb.enabled }}
+      {{- if .Values.pdb.maxUnavailable }}
       maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+      {{- end  }}
+      {{- if .Values.pdb.minAvailable }}
       minAvailable: {{ .Values.pdb.minAvailable }}
+      {{- end  }}
 {{- end }}
   redisExporter:
     enabled: {{ .Values.redisExporter.enabled }}

--- a/charts/redis-cluster/values.yaml
+++ b/charts/redis-cluster/values.yaml
@@ -48,7 +48,6 @@ redisCluster:
 pdb:
   enabled: true
   maxUnavailable: 1
-  minAvailable: 1
 
 externalConfig:
   enabled: false


### PR DESCRIPTION
Fixes: https://github.com/OT-CONTAINER-KIT/helm-charts/issues/49

Let me know if I should disable pdb by default.

Inspiration taken from https://github.com/helm/charts/blob/master/stable/kubernetes-dashboard/templates/pdb.yaml