### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: azure/setup-helm@v1
         with:
           version: v3.5.0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Set up chart-testing

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Helm

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.5.0
       - uses: actions/setup-python@v4

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.3.1
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Lint Code Base
         uses: docker://github/super-linter:v3.12.0
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch history
         run: git fetch --prune --unshallow


### PR DESCRIPTION
1. ci: update actions/checkout to v3
2. ci: update actions/setup-python to v4
3. ci: update azure/setup-helm to v3
4. ci: update helm/chart-testing-action to v2.3.1

Additional notes:
helm/chart-releaser-action can also be updated to v1.4.1 and linked https://github.com/helm/chart-releaser-action/issues/6 is now closed so probably "Install Helm" is no longer required.