### PR TITLE
Fix ExternalLoadBalancer annotations

### DIFF
--- a/charts/redis-cluster/templates/follower-service.yaml
+++ b/charts/redis-cluster/templates/follower-service.yaml
@@ -19,7 +19,7 @@ spec:
   type: {{ .Values.externalService.serviceType }}
   selector:
     app: {{ .Release.Name }}-follower
-    redis_setup_type: follower
+    redis_setup_type: cluster
     role: follower
   ports:
     - protocol: TCP

--- a/charts/redis-cluster/templates/leader-service.yaml
+++ b/charts/redis-cluster/templates/leader-service.yaml
@@ -19,7 +19,7 @@ spec:
   type: {{ .Values.externalService.serviceType }}
   selector:
     app: {{ .Release.Name }}-leader
-    redis_setup_type: leader
+    redis_setup_type: cluster
     role: leader
   ports:
     - protocol: TCP


### PR DESCRIPTION
Currently the helm chart sets the leader/follower selector to leader/follower respectively.

When setting external to true, both external load balancers are set to use redis_setup_type=cluster.

If deployed as is then the external load balancers have no endpoints as the labels do not match. This fixes that