### PR TITLE
Update redis-standalone.yaml

### DIFF
--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -16,6 +16,9 @@ metadata:
 {{- end }}
 {{- end }}
 spec:
+{{- if .Values.serviceAccountName }}
+  serviceAccountName: "{{ .Values.serviceAccountName }}"
+{{- end }} 
 {{- if eq .Values.externalConfig.enabled true }}
   redisConfig:
     additionalRedisConfig: redis-external-config


### PR DESCRIPTION
add possibility to define serviceaccount. In openshift, it's necessary to add SCC to this service account to permit run as user 1000