### PR TITLE
removed deprecated pdb block

### DIFF
--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -98,12 +98,6 @@ spec:
   sidecars:
 {{ toYaml .Values.sidecars | indent 4 }}
 {{- end }}
-{{- if eq .Values.pdb.enabled true }}
-  pdb:
-    enabled: {{ .Values.pdb.enabled }}
-    maxUnavailable: {{ .Values.pdb.maxUnavailable }}
-    minAvailable: {{ .Values.pdb.minAvailable }}
-{{- end }}
 {{- if .Values.serviceAccountName }}
   serviceAccountName: "{{ .Values.serviceAccountName }}"
 {{- end }}


### PR DESCRIPTION
as of redis-operator 0.13.1 the top level pdb block isn't valid anymore, so it has to be removed