### PR TITLE
redis-operator: Add `extraArgs` option argument to allow providing additional arguments. (#82)

### DIFF
--- a/charts/redis-operator/templates/operator-deployment.yaml
+++ b/charts/redis-operator/templates/operator-deployment.yaml
@@ -36,6 +36,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        {{- range $arg := .Values.redisOperator.extraArgs }}
+        - {{ $arg }}
+        {{- end }}
 {{- if .Values.watch_namespace }}
         env:
           - name: NAMESPACE

--- a/charts/redis-operator/values.yaml
+++ b/charts/redis-operator/values.yaml
@@ -10,6 +10,10 @@ redisOperator:
   podAnnotations: {}
   # Additional Pod labels (e.g. for filtering Pod by custom labels)
   podLabels: {}
+  
+  # Additional arguments for redis-operator container
+  extraArgs: []
+  #  - -zap-log-level=error
 
 # watch_namespace: ot-operators
 


### PR DESCRIPTION
Resolves #82 