### PR TITLE
feature: Add pod annotations to redis cluster template.

### DIFF
--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -15,6 +15,10 @@ metadata:
     {{ $labelkey}}: {{ $labelvalue }}
 {{- end }}
 {{- end }}
+{{- with .Values.annotations }}
+  annotations:
+{{- toYaml . | nindent 6 }}
+{{- end }}
 spec:
   clusterSize: {{ .Values.redisCluster.clusterSize }}
   persistenceEnabled: {{ .Values.redisCluster.persistenceEnabled }}


### PR DESCRIPTION
This change would be very usefull for us as we are migrating from tug and still need to keep a lot of metadata on the pod.  Thank you for considering adding this change.