### PR TITLE
Fix: mongo storage class

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: mongodb
 sources:
   - https://github.com/ot-container-kit/mongodb-operator
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.3.0"
 home: https://github.com/ot-container-kit/mongodb-operator
 keywords:

--- a/charts/mongodb/templates/mongodb.yaml
+++ b/charts/mongodb/templates/mongodb.yaml
@@ -40,7 +40,9 @@ spec:
   storage:
     accessModes: {{ .Values.storage.accessModes }}
     storageSize: {{ .Values.storage.storageSize }}
+{{- if .Values.storage.storageClass }}
     storageClass: {{ .Values.storage.storageClass }}
+{{- end }}
 {{- end }}
   mongoDBSecurity:
     mongoDBAdminUser: admin

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -40,10 +40,10 @@ storage:
   enabled: true
   accessModes: ["ReadWriteOnce"]
   storageSize: 1Gi
-  storageClass: csi-cephfs-sc
+  storageClass:
 
 mongoDBMonitoring:
-  enabled: true
+  enabled: false
   image:
     name: bitnami/mongodb-exporter
     tag: 0.11.2-debian-10-r382


### PR DESCRIPTION
If the storage Class is not provided then use the default one. 