### PR TITLE
Bug : Field Name change from securityContext to podSecurityContext

### DIFF
--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -8,9 +8,9 @@ maintainers:
 name: redis-cluster
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.14.3
+version: 0.15.0
 
-appVersion: "0.14.0"
+appVersion: "0.15.0"
 home: https://github.com/ot-container-kit/redis-operator
 keywords:
 - operator

--- a/charts/redis-cluster/Chart.yaml
+++ b/charts/redis-cluster/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: redis-cluster
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.15.0
+version: 0.15.1
 
 appVersion: "0.15.0"
 home: https://github.com/ot-container-kit/redis-operator

--- a/charts/redis-cluster/templates/redis-cluster.yaml
+++ b/charts/redis-cluster/templates/redis-cluster.yaml
@@ -86,9 +86,9 @@ spec:
   nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 4 }}
 {{- end }}
-{{- if .Values.securityContext }}
-  securityContext:
-{{ toYaml .Values.securityContext | indent 4 }}
+{{- if .Values.podSecurityContext }}
+  podSecurityContext:
+{{ toYaml .Values.podSecurityContext | indent 4 }}
 {{- end }}
 {{- if .Values.tolerations }}
   tolerations:

--- a/charts/redis-operator/Chart.yaml
+++ b/charts/redis-operator/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-version: 0.14.3
-appVersion: "0.14.0"
+version: 0.15.0
+appVersion: "0.15.0"
 description: Provides easy redis setup definitions for Kubernetes services, and deployment.
 engine: gotpl
 maintainers:

--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
   - name: shubham-cmyk
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.15.0
+version: 0.15.1
 appVersion: "0.15.0"
 home: https://github.com/ot-container-kit/redis-operator
 keywords:

--- a/charts/redis-replication/Chart.yaml
+++ b/charts/redis-replication/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
   - name: shubham-cmyk
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.14.2
-appVersion: "0.14.0"
+version: 0.15.0
+appVersion: "0.15.0"
 home: https://github.com/ot-container-kit/redis-operator
 keywords:
 - operator

--- a/charts/redis-replication/templates/redis-replication.yaml
+++ b/charts/redis-replication/templates/redis-replication.yaml
@@ -62,9 +62,9 @@ spec:
   affinity:
 {{ toYaml .Values.affinity | indent 4 }}
 {{- end }}
-{{- if .Values.securityContext }}
-  securityContext:
-{{ toYaml .Values.securityContext | indent 4 }}
+{{- if .Values.podSecurityContext }}
+  podSecurityContext:
+{{ toYaml .Values.podSecurityContext | indent 4 }}
 {{- end }}
 {{- if .Values.tolerations }}
   tolerations:

--- a/charts/redis-replication/values.yaml
+++ b/charts/redis-replication/values.yaml
@@ -108,7 +108,7 @@ storageSpec:
 
   #   selector: {}
 
-securityContext:
+podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000
 

--- a/charts/redis-sentinel/Chart.yaml
+++ b/charts/redis-sentinel/Chart.yaml
@@ -9,8 +9,8 @@ maintainers:
 name: redis-sentinel
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.14.3
-appVersion: "0.14.0"
+version: 0.15.0
+appVersion: "0.15.0"
 home: https://github.com/ot-container-kit/redis-operator
 keywords:
 - operator

--- a/charts/redis-sentinel/Chart.yaml
+++ b/charts/redis-sentinel/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: redis-sentinel
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.15.0
+version: 0.15.1
 appVersion: "0.15.0"
 home: https://github.com/ot-container-kit/redis-operator
 keywords:

--- a/charts/redis-sentinel/templates/redis-sentinel.yaml
+++ b/charts/redis-sentinel/templates/redis-sentinel.yaml
@@ -58,9 +58,9 @@ spec:
   affinity:
 {{ toYaml .Values.affinity | indent 4 }}
 {{- end }}
-{{- if .Values.securityContext }}
-  securityContext:
-{{ toYaml .Values.securityContext | indent 4 }}
+{{- if .Values.podSecurityContext }}
+  podSecurityContext:
+{{ toYaml .Values.podSecurityContext | indent 4 }}
 {{- end }}
 {{- if .Values.tolerations }}
   tolerations:

--- a/charts/redis-sentinel/values.yaml
+++ b/charts/redis-sentinel/values.yaml
@@ -108,7 +108,7 @@ storageSpec:
           storage: 1Gi
   #   selector: {}
 
-securityContext:
+podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000
 

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: redis
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.15.0
+version: 0.15.1
 appVersion: "0.15.0"
 home: https://github.com/ot-container-kit/redis-operator
 keywords:

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -8,8 +8,8 @@ maintainers:
 name: redis
 sources:
   - https://github.com/ot-container-kit/redis-operator
-version: 0.14.2
-appVersion: "0.14.0"
+version: 0.15.0
+appVersion: "0.15.0"
 home: https://github.com/ot-container-kit/redis-operator
 keywords:
 - operator

--- a/charts/redis/templates/redis-standalone.yaml
+++ b/charts/redis/templates/redis-standalone.yaml
@@ -61,9 +61,9 @@ spec:
   affinity:
 {{ toYaml .Values.affinity | indent 4 }}
 {{- end }}
-{{- if .Values.securityContext }}
-  securityContext:
-{{ toYaml .Values.securityContext | indent 4 }}
+{{- if .Values.podpodSecurityContext }}
+  podpodSecurityContext:
+{{ toYaml .Values.podpodSecurityContext | indent 4 }}
 {{- end }}
 {{- if .Values.tolerations }}
   tolerations:

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -98,7 +98,7 @@ storageSpec:
           storage: 1Gi
   #   selector: {}
 
-securityContext:
+podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000
 


### PR DESCRIPTION
Since we are supporting the security at pod level and container level which is added by : https://github.com/OT-CONTAINER-KIT/redis-operator/pull/518
There is a need to change field name from securityContext to podSecurityContext. 
Which mention explicitly that security level of it. 

securityContext refers to container Level 
podSecurityContext refers to Pod Level 