### PR TITLE
Added tempo-standalone, blackbox and vm-standalone Helm charts

### DIFF
--- a/charts/blackbox-exporter/Chart.yaml
+++ b/charts/blackbox-exporter/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: blackbox
+appVersion: v0.28.0
+description: A Helm chart for blackbox-exporter
+type: application
+version: 0.0.1
+maintainers:
+  - name: ashwani-opstree
+    email: ashwani.singh@opstree.com
+  - name: Varunarora2201
+    email: varun.kumar@opstree.com
+dependencies:
+- name: prometheus-blackbox-exporter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 11.9.1

--- a/charts/blackbox-exporter/values.yaml
+++ b/charts/blackbox-exporter/values.yaml
@@ -1,0 +1,44 @@
+prometheus-blackbox-exporter:
+  enabled: true
+  fullnameOverride: blackbox
+
+  image:
+    registry: quay.io
+    repository: opstree/blackbox-exporter
+    tag: "0"
+
+  rbac:
+    create: true
+
+  resources:
+    limits:
+      cpu: 300m
+      memory: 300Mi
+    requests:
+      cpu: 150m
+      memory: 150Mi
+
+  tolerations:
+    - effect: NoExecute
+      operator: Exists
+    - effect: NoSchedule
+      operator: Exists
+
+  config:
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 10s
+        http:
+          valid_http_versions:
+            - "HTTP/1.0"
+            - "HTTP/1.1"
+            - "HTTP/2.0"
+          no_follow_redirects: false
+          preferred_ip_protocol: "ip4"
+          fail_if_ssl: false
+          fail_if_not_ssl: false
+          tls_config:
+            insecure_skip_verify: true
+          headers:
+            User-Agent: "blackbox-exporter"

--- a/charts/loki/Chart.yaml
+++ b/charts/loki/Chart.yaml
@@ -1,27 +1,17 @@
 apiVersion: v2
-name: loki
-description: A Helm chart for loki
+name: loki-standalone
+appVersion: "3"
+description: A Helm chart for Loki standalone setup
 type: application
-version: 1.0.1
-appVersion: 1.0.0
+version: 1.0.0
+maintainers:
+  - name: ashwani-opstree
+    email: ashwani.singh@opstree.com
+  - name: Varunarora2201
+    email: varun.kumar@opstree.com
 dependencies:
-  - name: loki-distributed
-    version: 0.76.1
-    repository: https://grafana.github.io/helm-charts
-    alias: distributed
-    tags:
-      - logging
-    condition: distributed.enabled
-  - name: promtail
-    version: 6.16.4
-    repository: https://grafana.github.io/helm-charts
-    alias: promtail
-    tags:
-      - logging
   - name: loki
-    version: 6.7.3
+    version: 6.38.0
     repository: https://grafana.github.io/helm-charts
-    alias: standalone
-    tags:
-      - logging
-    condition: standalone.enabled
+    alias: loki
+    condition: loki.enabled

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -1,14 +1,43 @@
-distributed:
-  enabled: false
-
-standalone:
+loki:
   enabled: true
+
   loki:
+    image:
+      registry: ""
+      repository: quay.io/opstree/loki
+      tag: "3"
+      digest: ""
+
+    auth_enabled: false
+
+    limits_config:
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h
+      max_cache_freshness_per_query: 10m
+      split_queries_by_interval: 15m
+      per_stream_rate_limit: 512M
+      per_stream_rate_limit_burst: 1024M
+      cardinality_limit: 200000
+      ingestion_burst_size_mb: 1000
+      ingestion_rate_mb: 10000
+      max_entries_limit_per_query: 1000000
+      max_label_value_length: 20480
+      max_label_name_length: 10240
+      max_label_names_per_series: 300
+
+    compactor:
+      working_directory: /var/loki/compactor
+      compaction_interval: 10m
+      retention_enabled: false
+      delete_request_store: filesystem
+      retention_delete_delay: 2h
+
     storage:
       type: filesystem
-    auth_enabled: false
+
     commonConfig:
       replication_factor: 1
+
     schemaConfig:
       configs:
         - from: 2024-04-01
@@ -18,52 +47,111 @@ standalone:
           index:
             prefix: loki_index_
             period: 24h
+
     ingester:
       chunk_encoding: snappy
+
     tracing:
-      enabled: true
+      enabled: false
+
     querier:
-      # Default is 4, if you have enough memory and CPU you can increase, reduce if OOMing
       max_concurrent: 2
 
+  serviceAccount:
+    create: true
+
   deploymentMode: SingleBinary
+
   lokiCanary:
     enabled: false
+
   test:
     enabled: false
+
   singleBinary:
+    affinity: ""
     replicas: 1
+
+    initContainers:
+      - name: volume-permissions
+        image: quay.io/opstree/busybox:1-alpine3.23
+        command:
+          - sh
+          - -c
+          - |
+            chown -R 10001:10001 /var/loki
+        volumeMounts:
+          - name: storage
+            mountPath: /var/loki
+
     resources:
       limits:
-        cpu: 3
-        memory: 4Gi
-      requests:
-        cpu: 2
+        cpu: "2"
         memory: 2Gi
-    extraEnv:
-      # Keep a little bit lower than memory limits
-      - name: GOMEMLIMIT
-        value: 3750MiB
+      requests:
+        cpu: 500m
+        memory: 1Gi
+
+    persistence:
+      enabled: true
+      size: 10Gi
+      storageClass: standard
+
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+
+  gateway:
+    affinity: ""
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
 
   chunksCache:
-    # default is 500MB, with limited memory keep this smaller
     writebackSizeLimit: 10MB
-    allocatedMemory: 1024
+    allocatedMemory: 250Mi
+    image:
+      repository: quay.io/opstree/memcached
+      tag: "1"
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+    exporter:
+      image:
+        repository: quay.io/opstree/memcached-exporter
+        tag: "0"
 
-  # Enable minio for storage
+  resultsCache:
+    allocatedMemory: 128Mi
+    image:
+      repository: quay.io/opstree/memcached
+      tag: "1"
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+    exporter:
+      image:
+        repository: quay.io/opstree/memcached-exporter
+        tag: "0"
+
   minio:
     enabled: false
-    persistence:
-      size: 10Gi
 
-  # Zero out replica counts of other deployment modes
+  # Zero out all non-SingleBinary replicas
   backend:
     replicas: 0
   read:
     replicas: 0
   write:
     replicas: 0
-
   ingester:
     replicas: 0
   querier:
@@ -82,9 +170,3 @@ standalone:
     replicas: 0
   bloomGateway:
     replicas: 0
-
-promtail:
-  config:
-    logLevel: info
-    clients:
-      - url: http://logging-gateway/loki/api/v1/push

--- a/charts/otel-collector/Chart.yaml
+++ b/charts/otel-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-name: otel-operator
-appVersion: "0.124.0"
-description: A Helm chart for OpenTelemetry Operator
+name: otel-collector
+appVersion: "0.129.0"
+description: A Helm chart for OpenTelemetry Collector
 type: application
 version: 1.0.0
 maintainers:
@@ -10,8 +10,9 @@ maintainers:
   - name: Varunarora2201
     email: varun.kumar@opstree.com
 dependencies:
-  - name: opentelemetry-operator
-    version: 0.102.0
+  - name: opentelemetry-collector
+    version: 0.123.0
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    alias: operator
-    condition: operator.enabled
+    alias: collector
+    condition: collector.enabled
+ 

--- a/charts/otel-collector/Values.yaml
+++ b/charts/otel-collector/Values.yaml
@@ -1,0 +1,159 @@
+collector:
+  enabled: true
+
+  image:
+    repository: quay.io/opstree/opentelemetry-collector
+    tag: "0-contrib"
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  mode: deployment
+
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
+  tolerations:
+    - effect: NoExecute
+      operator: Exists
+    - effect: NoSchedule
+      operator: Exists
+
+  config:
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+      pprof:
+        endpoint: 0.0.0.0:1777
+      zpages:
+        endpoint: 0.0.0.0:55679
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            max_recv_msg_size_mib: 16
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: otelcol-metrics
+              scrape_interval: 30s
+              static_configs:
+                - targets: [127.0.0.1:8888]
+
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 90
+        spike_limit_percentage: 14
+      batch:
+        send_batch_max_size: 10000
+        send_batch_size: 5000
+        timeout: 5s
+      batch/tempo:
+        send_batch_max_size: 128
+        send_batch_size: 64
+        timeout: 5s
+
+    connectors:
+      spanmetrics:
+        dimensions:
+          - name: http.method
+          - name: http.status_code
+          - name: http.route
+          - name: rpc.grpc.status_code
+          - name: rpc.service
+          - name: rpc.system
+        dimensions_cache_size: 1000
+        metrics_expiration: 5m
+        metrics_flush_interval: 15s
+        resource_metrics_key_attributes:
+          - service.name
+          - telemetry.sdk.language
+          - telemetry.sdk.name
+      servicegraph:
+        dimensions:
+          - db.system
+          - messaging.system
+        store:
+          max_items: 500
+          ttl: 5s
+        virtual_node_peer_attributes:
+          - db.name
+          - db.system
+          - messaging.system
+          - peer.service
+
+    exporters:
+      otlp:
+        endpoint: tempo:4317
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 10000
+        retry_on_failure:
+          enabled: true
+        compression: snappy
+        timeout: 120s
+      prometheusremotewrite:
+        endpoint: "http://vmsingle-vm.monitoring.svc.cluster.local:8429/api/v1/write"
+        max_batch_size_bytes: 3000000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 300s
+          max_interval: 30s
+        timeout: 120s
+        tls:
+          insecure_skip_verify: true
+
+    service:
+      extensions:
+        - health_check
+        - pprof
+        - zpages
+      pipelines:
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch/tempo
+          exporters:
+            - otlp
+            - spanmetrics
+            - servicegraph
+        metrics:
+          receivers:
+            - otlp
+            - prometheus
+            - spanmetrics
+            - servicegraph
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - prometheusremotewrite
+      telemetry:
+        metrics:
+          level: detailed
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: 127.0.0.1
+                    port: 8888

--- a/charts/otel-operator/values.yaml
+++ b/charts/otel-operator/values.yaml
@@ -1,12 +1,71 @@
 operator:
   enabled: true
-  fullnameOverride: otel
+  fullnameOverride: otel-operator
+
+  replicaCount: 1
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  resources:
+    limits:
+      cpu: 300m
+      memory: 300Mi
+    requests:
+      cpu: 150m
+      memory: 150Mi
+
+  tolerations:
+    - effect: NoExecute
+      operator: Exists
+    - effect: NoSchedule
+      operator: Exists
+
   manager:
+    image:
+      repository: quay.io/opstree/opentelemetry-operator
+      tag: "0"
+
     collectorImage:
-      repository: otel/opentelemetry-collector-contrib
-      tag: latest
+      repository: quay.io/opstree/opentelemetry-collector
+      tag: "0-contrib"
+
+    kube-rbac-proxy:
+      image:
+        repository: quay.io/opstree/kube-rbac-proxy
+        tag: "0"
+
+    autoInstrumentationImage:
+      java:
+        repository: quay.io/opstree/otel-autoinstrumentation-java
+        tag: 2.19.0
+      nodejs:
+        repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs
+        tag: 0.58.0
+      go: 
+        repository: ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go
+        tag: v0.19.0-alpha
+      python:
+        repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python
+        tag: 0.53b1
+      dotnet:
+        repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-dotnet
+        tag: 1.2.0
+      apacheHttpd:
+        repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-apache-httpd
+        tag: 1.0.4
+
+    serviceMonitor:
+      enabled: true
+
   admissionWebhooks:
     certManager:
       enabled: false
     autoGenerateCert:
       enabled: true
+      recreate: false
+      certPeriodDays: 3650

--- a/charts/tempo-standalone/Chart.yaml
+++ b/charts/tempo-standalone/Chart.yaml
@@ -1,14 +1,17 @@
 apiVersion: v2
 name: tempo-standalone
-description: A Helm chart for tempo standalone
+appVersion: "2"
+description: A Helm chart for Tempo Standalone setup
 type: application
 version: 1.0.0
-appVersion: 1.0.0
+maintainers:
+  - name: ashwani-opstree
+    email: ashwani.singh@opstree.com
+  - name: Varunarora2201
+    email: varun.kumar@opstree.com
 dependencies:
-  - name: tempo
-    version: 1.10.1
-    repository: https://grafana.github.io/helm-charts
-    alias: tempo
-    tags:
-      - tempo
+  - alias: tempo
     condition: tempo.enabled
+    name: tempo
+    repository: https://grafana.github.io/helm-charts
+    version: 1.23.0

--- a/charts/tempo-standalone/values.yaml
+++ b/charts/tempo-standalone/values.yaml
@@ -1,18 +1,61 @@
 tempo:
   enabled: true
   fullnameOverride: tempo
+
+  image:
+    registry: ""
+    repository: quay.io/opstree/tempo
+    tag: "2"
+
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    runAsNonRoot: true
+    fsGroup: 1000
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  rbac:
+    create: true
+
+  service:
+    type: ClusterIP
+
+  resources:
+    limits:
+      cpu: 300m
+      memory: 300Mi
+    requests:
+      cpu: 150m
+      memory: 150Mi
+
+  tolerations:
+    - effect: NoExecute
+      operator: Exists
+    - effect: NoSchedule
+      operator: Exists
+
   tempo:
-    retention: 168h
-    resources:
-      requests:
-        cpu:  1
-        memory: 2Gi
-      limits:
-        cpu: 1
-        memory: 2Gi
+    retention: 24h
+    memBallastSizeMbs: 1024
+
+    metricsGenerator:
+      enabled: false
 
   persistence:
     enabled: true
+    size: 10Gi
+    storageClassName: o11y-gp3-storage
 
-  serviceMonitor:
-    enabled: true
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"

--- a/charts/tempo-standalone/values.yaml
+++ b/charts/tempo-standalone/values.yaml
@@ -59,3 +59,16 @@ tempo:
           endpoint: "0.0.0.0:4317"
         http:
           endpoint: "0.0.0.0:4318"
+          
+  # Add this section to fix permissions
+  initContainers:
+    - name: volume-permissions
+      image: quay.io/opstree/busybox:1-alpine3.23
+      command:
+        - sh
+        - -c
+        - |
+          chown -R 1000:1000 /var/tempo
+      volumeMounts:
+        - name: storage
+          mountPath: /var/tempo

--- a/charts/victoriametrics/Chart.yaml
+++ b/charts/victoriametrics/Chart.yaml
@@ -1,31 +1,22 @@
 apiVersion: v2
-name: vm
-description: A Helm chart for victoriametrics
+name: vm-standalone
+appVersion: "0.58.0"
+description: A Helm chart for Victoria Metrics K8s stack standalone setup
 type: application
-version: 0.0.3
-appVersion: v0.0.3
+version: 1.0.0
 maintainers:
   - name: ashwani-opstree
-
+    email: ashwani.singh@opstree.com
+  - name: Varunarora2201
+    email: varun.kumar@opstree.com
 dependencies:
   - name: victoria-metrics-k8s-stack
-    version: 0.25.5
+    version: 0.58.0
     repository: https://victoriametrics.github.io/helm-charts/
     alias: vm
-    tags:
-      - monitoring
     condition: vm.enabled
-  - name: prometheus-blackbox-exporter
-    version: 8.17.0
-    repository: https://prometheus-community.github.io/helm-charts/
-    tags:
-      - blackbox
-    alias: blackbox
-    condition: blackbox.enabled
-  - name: prometheus-msteams
-    version: 1.3.4
-    repository: https://prometheus-msteams.github.io/prometheus-msteams/
-    tags:
-      - msteams
-    alias: msteams
-    condition: msteams.enabled
+  - name: prometheus-operator-crds
+    version: "20.0.1"
+    repository: https://prometheus-community.github.io/helm-charts
+    alias: prometheus-operator-crds
+    condition: prometheus-operator-crds.enabled

--- a/charts/victoriametrics/values.yaml
+++ b/charts/victoriametrics/values.yaml
@@ -106,6 +106,19 @@ vm:
         - effect: NoSchedule
           operator: Exists
 
+  # Add this section to fix permissions  
+    initContainers:
+      - name: volume-permissions
+        image: quay.io/opstree/busybox:1-alpine3.23
+        command:
+          - sh
+          - -c
+          - |
+            chown -R 1000:1000 /storage
+        volumeMounts:
+          - name: data
+            mountPath: /storage
+
   ## VMAgent ##
 
   vmagent:

--- a/charts/victoriametrics/values.yaml
+++ b/charts/victoriametrics/values.yaml
@@ -1,233 +1,202 @@
 vm:
+  enabled: true
+
+  
+  ## VM Operator ##
+
   victoria-metrics-operator:
-    cleanupCRD: false
-  defaultDashboardsEnabled: false
-  experimentalDashboardsEnabled: false
-  prometheus-node-exporter:
     enabled: true
-  node:
-    enabled: true
-  kubeStateMetrics:
-    enabled: true
-  grafana:
-    enabled: true
-    testFramework:
-      enabled: false
-    sidecar:
-      datasources:
-        defaultDatasourceEnabled: false
+
+    image:
+      registry: quay.io
+      repository: opstree/victoriametrics/operator
+      tag: "107f97f"
+
     resources:
-      requests:
-        cpu: "0.5"
-        memory: 1Gi
       limits:
-        cpu: 1
-        memory: 2Gi
-    persistence:
+        cpu: 200m
+        memory: 500Mi
+      requests:
+        cpu: 100m
+        memory: 300Mi
+
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+
+    serviceMonitor:
       enabled: true
-      type: sts
-      storageClassName: buildpiper-storage
-      accessModes:
-        - ReadWriteOnce
-      size: 1Gi
-      finalizers:
-        - kubernetes.io/pvc-protection
-    # nodeSelector:
-    #   node_group: o11y
-    # tolerations:
-    #   - key: o11y
-    #     operator: Equal
-    #     value: "true"
-    #     effect: NoSchedule
+
+    operator:
+      disable_prometheus_converter: false
+
+    env:
+      # opstree hardened images — identified and pushed
+      - name: VM_VMSINGLEDEFAULT_IMAGE
+        value: "quay.io/opstree/victoriamertics-victoriametrics:v1.40.0"
+      - name: VM_VMAGENTDEFAULT_IMAGE
+        value: "quay.io/opstree/victoriametrics-vmagent:1"
+      - name: VM_VMALERTDEFAULT_IMAGE
+        value: "quay.io/opstree/victoriametrics-vmalert:1"
+      - name: VM_VMALERTMANAGER_ALERTMANAGERDEFAULTBASEIMAGE
+        value: "quay.io/opstree/alertmanager"
+      # upstream images — not yet hardened
+      - name: VM_VLOGSDEFAULT_IMAGE
+        value: "quay.io/victoriametrics/victoria-logs"
+      - name: VM_VMCLUSTERDEFAULT_VMSELECTDEFAULT_IMAGE
+        value: "quay.io/victoriametrics/vmselect"
+      - name: VM_VMCLUSTERDEFAULT_VMSTORAGEDEFAULT_IMAGE
+        value: "quay.io/victoriametrics/vmstorage"
+      - name: VM_VMCLUSTERDEFAULT_VMINSERTDEFAULT_IMAGE
+        value: "quay.io/victoriametrics/vminsert"
+      - name: VM_VMBACKUP_IMAGE
+        value: "quay.io/victoriametrics/vmbackupmanager"
+      - name: VM_VMAUTHDEFAULT_IMAGE
+        value: "quay.io/victoriametrics/vmauth"
+
+  ## Grafana — managed via standalone grafana chart
+
+  grafana:
+    enabled: false
+
+  ## Alertmanager ##
+
   alertmanager:
     enabled: true
-    config:
-      global:
-        resolve_timeout: 5m
-      templates:
-        - "/etc/vm/configs/**/*.tmpl"
-      route:
-        receiver: "blackhole"
-      receivers:
-      - name: blackhole
     spec:
-      configNamespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: monitoring
-      replicaCount: 2
-      retention: 240h
+      replicaCount: 1
       resources:
-        requests:
-          cpu: 250m
-          memory: 500Mi
         limits:
           cpu: 250m
           memory: 500Mi
-      # nodeSelector:
-      #   node_group: o11y
-      # tolerations:
-      #   - key: o11y
-      #     operator: Equal
-      #     value: "true"
-      #     effect: NoSchedule
-      storage:
-        volumeClaimTemplate:
-          spec:
-            storageClassName: buildpiper-storage
-            accessModes:
-              - "ReadWriteOnce"
-            resources:
-              requests:
-                storage: 1Gi
-  vmsingle:
-    enabled: false
-  defaultRules:
-    create: false
-  kubeApiServer:
-    enabled: false
-  kubeControllerManager:
-    enabled: false
-  kubeEtcd:
-    enabled: false
-  kubeScheduler:
-    enabled: false
-  crds:
-    enabled: false
-  dashboards:
-    node-exporter-full: false
+        requests:
+          cpu: 100m
+          memory: 500Mi
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
 
-  vmcluster:
+  ## VMSingle ##
+  
+  vmsingle:
     enabled: true
     spec:
-      retentionPeriod: "14d"
-      replicationFactor: 1
-      vmstorage:
-        replicaCount: 1
-        extraArgs:
-          search.maxUniqueTimeseries: "10000000000000"
+      retentionPeriod: "7d"
+      resources:
+        limits:
+          cpu: "1"
+          memory: 1Gi
+        requests:
+          cpu: "1"
+          memory: 1Gi
+      storage:
+        storageClassName: standard
+        accessModes:
+          - ReadWriteOnce
         resources:
-          limits:
-            cpu: "0.5"
-            memory: 500Mi
           requests:
-            cpu: "0.5"
-            memory: 500Mi
-        storage:
-          volumeClaimTemplate:
-            spec:
-              storageClassName: buildpiper-storage
-              resources:
-                requests:
-                  storage: 20Gi
-        # nodeSelector: {}
-        # tolerations: {}
-      vmselect:
-        replicaCount: 1
-        extraArgs:
-          memory.allowedPercent: "75"
-          search.cacheTimestampOffset: 60m
-          search.maxLabelsAPISeries: "10000000000000"
-          search.maxMemoryPerQuery: 2GB
-          search.maxPointsPerTimeseries: "10000000000000"
-          search.maxQueryDuration: 10m
-          search.maxQueryLen: "10000000000000"
-          search.maxSeries: "10000000000000"
-          search.maxUniqueTimeseries: "10000000000000"
-        storage:
-          volumeClaimTemplate:
-            spec:
-              storageClassName: buildpiper-storage
-              resources:
-                requests:
-                  storage: 2Gi
-        resources:
-          limits:
-            cpu: "1"
-            memory: "1Gi"
-          requests:
-            cpu: "1"
-            memory: "1Gi"
-        # nodeSelector: {}
-        # tolerations: {}
-      vminsert:
-        replicaCount: 1
-        extraArgs:
-          maxLabelsPerTimeseries: "100"
-        image:
-          tag: v1.103.0-cluster
-        resources:
-          limits:
-            cpu: "0.5"
-            memory: 500Mi
-          requests:
-            cpu: "0.5"
-            memory: "500Mi"
-        # nodeSelector: {}
-        # tolerations: {}
+            storage: 10Gi
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+
+  ## VMAgent ##
 
   vmagent:
     enabled: true
     spec:
-      serviceScrapeNamespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: vm
-      extraArgs:
-        promscrape.maxScrapeSize: 200MB
-        promscrape.streamParse: "true"
-        promscrape.dropOriginalLabels: "true"
+      scrapeInterval: 30s
       resources:
         limits:
-          cpu: "0.5"
+          cpu: 500m
           memory: 500Mi
         requests:
-          cpu: "0.5"
+          cpu: 100m
           memory: 500Mi
-      scrapeInterval: 30s
-      # nodeSelector: {}
-      # tolerations: {}
-      
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+
+  ## VMAlert ##
+  
   vmalert:
     enabled: true
     spec:
       resources:
         limits:
-          cpu: "0.5"
+          cpu: 500m
           memory: 500Mi
         requests:
-          cpu: "0.5"
+          cpu: 100m
           memory: 500Mi
-      # nodeSelector: {}
-      # tolerations: {}
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
 
-blackbox:
-  enabled: false
-  serviceMonitor:
+  ## Kube State Metrics ##
+
+  kube-state-metrics:
+    image:
+      registry: ""
+      repository: quay.io/opstree/kube-state-metrics
+      tag: "2"
+      digest: ""
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+
+  ## Node Exporter ##
+
+  prometheus-node-exporter:
+    image:
+      registry: quay.io
+      repository: opstree/node-exporter
+      tag: "1-alpine3"
+    resources:
+      limits:
+        cpu: 100m
+        memory: 64Mi
+      requests:
+        cpu: 10m
+        memory: 32Mi
+    tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+
+  
+  ## Disabled by default ##
+
+  defaultDashboards:
     enabled: false
-  config:
-    modules:
-      http_2xx:
-        prober: http
-        timeout: 5s
-        http:
-          valid_http_versions:
-            - "HTTP/1.0"
-            - "HTTP/1.1"
-            - "HTTP/2.0"
-          no_follow_redirects: false
-          preferred_ip_protocol: "ip4"
-          fail_if_ssl: false
-          fail_if_not_ssl: false
 
-msteams:
+  defaultRules:
+    create: false
+
+  vmcluster:
+    enabled: false
+
+## Prometheus Operator CRDs — disabled, VM operator handles CRDs ##
+
+prometheus-operator-crds:
   enabled: false
-  image:
-    repository: quay.io/prometheusmsteams/prometheus-msteams
-    tag: 1.5.2
-  resources:
-   limits:
-     cpu: 200m
-     memory: 500Mi
-   requests:
-     cpu: 100m
-     memory: 250Mi
-  connectors: []


### PR DESCRIPTION
### Summary
Adds OpsTree-managed Helm charts wrapping upstream community charts as dependencies with hardened `quay.io/opstree` images, minimal production defaults, and write permission handling via busybox initContainers.

### Charts Added
| Chart | Upstream Dependency | Version |
|---|---|---|
| `tempo-standalone` | `grafana/tempo` | 1.23.0 |
| `loki-standalone` | `grafana/loki` | 6.38.0 |
| `blackbox` | `prometheus-community/prometheus-blackbox-exporter` | 11.9.1 |
| `vm-standalone` | `victoriametrics/victoria-metrics-k8s-stack` | 0.58.0 |
| `otel-operator` | `open-telemetry/opentelemetry-operator` | 0.102.0 |
| `otel-collector` | `open-telemetry/opentelemetry-collector` | 0.123.0 |

### Hardened Images
| Component | Image |
|---|---|
| Tempo | `quay.io/opstree/tempo:2` |
| Loki | `quay.io/opstree/loki:3` |
| Blackbox Exporter | `quay.io/opstree/blackbox-exporter:0` |
| VM Operator | `quay.io/opstree/victoriametrics/operator:107f97f` |
| VMSingle | `quay.io/opstree/victoriametrics-victoriametrics:v1.141.0` |
| VMAgent | `quay.io/opstree/victoriametrics-vmagent:1` |
| VMAlert | `quay.io/opstree/victoriametrics-vmalert:1` |
| Alertmanager | `quay.io/opstree/alertmanager:1` |
| Kube State Metrics | `quay.io/opstree/kube-state-metrics:2` |
| Node Exporter | `quay.io/opstree/node-exporter:1-alpine3` |
| Memcached | `quay.io/opstree/memcached:1` |
| Memcached Exporter | `quay.io/opstree/memcached-exporter:0` |
| OTel Operator | `quay.io/opstree/opentelemetry-operator:0` |
| OTel Collector | `quay.io/opstree/opentelemetry-collector:0-contrib` |
| Kube RBAC Proxy | `quay.io/opstree/kube-rbac-proxy:0` |

### Write Permission Handling
Added busybox initContainer (`quay.io/opstree/busybox:1-alpine3.23`) to all stateful charts to `chown` the data directory before the main container starts. Ensures correct write permissions on pod restart without data loss.

| Chart | Path | User:Group |
|---|---|---|
| VMSingle | `/storage` | `1000:1000` |
| Tempo | `/var/tempo` | `1000:1000` |
| Loki | `/var/loki` | `10001:10001` |

### Notes
- Grafana disabled in vm-standalone — will be managed via separate grafana chart
- VM components not yet hardened (`victoria-logs`, `vmselect`, `vmstorage`, `vminsert`, `vmauth`) retain upstream `quay.io/victoriametrics` images as they don't have any detected vulnerabilities so far.
- All charts follow `*-standalone` naming convention for future scalable and distributed variants where applicable
- Client-specific config (storageClass, retention, nodeSelectors, receivers) expected to be overridden in downstream repo