### PR TITLE
Added the otel-collector helm chart along with the latest image

### DIFF
--- a/charts/otel-collector/Chart.yaml
+++ b/charts/otel-collector/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: otel-collector
+appVersion: "0.129.0"
+description: A Helm chart for OpenTelemetry Collector
+type: application
+version: 1.0.0
+maintainers:
+  - name: ashwani-opstree
+    email: ashwani.singh@opstree.com
+  - name: Varunarora2201
+    email: varun.kumar@opstree.com
+dependencies:
+  - name: opentelemetry-collector
+    version: 0.123.0
+    repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+    alias: collector
+    condition: collector.enabled

--- a/charts/otel-collector/Chart.yaml
+++ b/charts/otel-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: otel-collector
-appVersion: "0.129.0"
+appVersion: "0.150.1"
 description: A Helm chart for OpenTelemetry Collector
 type: application
 version: 1.0.0

--- a/charts/otel-collector/Chart.yaml
+++ b/charts/otel-collector/Chart.yaml
@@ -3,7 +3,7 @@ name: otel-collector
 appVersion: "0.150.1"
 description: A Helm chart for OpenTelemetry Collector
 type: application
-version: 1.0.0
+version: 0.0.1
 maintainers:
   - name: ashwani-opstree
     email: ashwani.singh@opstree.com

--- a/charts/otel-collector/values.yaml
+++ b/charts/otel-collector/values.yaml
@@ -1,0 +1,159 @@
+collector:
+  enabled: true
+
+  image:
+    repository: quay.io/opstree/opentelemetry-collector
+    tag: "0.150.1-debian13-contrib"
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+
+  mode: deployment
+
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
+  tolerations:
+    - effect: NoExecute
+      operator: Exists
+    - effect: NoSchedule
+      operator: Exists
+
+  config:
+    extensions:
+      health_check:
+        endpoint: "0.0.0.0:13133"
+      pprof:
+        endpoint: 0.0.0.0:1777
+      zpages:
+        endpoint: 0.0.0.0:55679
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            max_recv_msg_size_mib: 16
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: otelcol-metrics
+              scrape_interval: 30s
+              static_configs:
+                - targets: [127.0.0.1:8888]
+
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 90
+        spike_limit_percentage: 14
+      batch:
+        send_batch_max_size: 10000
+        send_batch_size: 5000
+        timeout: 5s
+      batch/tempo:
+        send_batch_max_size: 128
+        send_batch_size: 64
+        timeout: 5s
+
+    connectors:
+      spanmetrics:
+        dimensions:
+          - name: http.method
+          - name: http.status_code
+          - name: http.route
+          - name: rpc.grpc.status_code
+          - name: rpc.service
+          - name: rpc.system
+        dimensions_cache_size: 1000
+        metrics_expiration: 5m
+        metrics_flush_interval: 15s
+        resource_metrics_key_attributes:
+          - service.name
+          - telemetry.sdk.language
+          - telemetry.sdk.name
+      servicegraph:
+        dimensions:
+          - db.system
+          - messaging.system
+        store:
+          max_items: 500
+          ttl: 5s
+        virtual_node_peer_attributes:
+          - db.name
+          - db.system
+          - messaging.system
+          - peer.service
+
+    exporters:
+      otlp:
+        endpoint: tempo:4317
+        tls:
+          insecure: true
+        sending_queue:
+          enabled: true
+          num_consumers: 10
+          queue_size: 10000
+        retry_on_failure:
+          enabled: true
+        compression: snappy
+        timeout: 120s
+      prometheusremotewrite:
+        endpoint: "http://vmsingle-vm.monitoring.svc.cluster.local:8429/api/v1/write"
+        max_batch_size_bytes: 3000000
+        retry_on_failure:
+          enabled: true
+          initial_interval: 5s
+          max_elapsed_time: 300s
+          max_interval: 30s
+        timeout: 120s
+        tls:
+          insecure_skip_verify: true
+
+    service:
+      extensions:
+        - health_check
+        - pprof
+        - zpages
+      pipelines:
+        traces:
+          receivers:
+            - otlp
+          processors:
+            - memory_limiter
+            - batch/tempo
+          exporters:
+            - otlp
+            - spanmetrics
+            - servicegraph
+        metrics:
+          receivers:
+            - otlp
+            - prometheus
+            - spanmetrics
+            - servicegraph
+          processors:
+            - memory_limiter
+            - batch
+          exporters:
+            - prometheusremotewrite
+      telemetry:
+        metrics:
+          level: detailed
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: 127.0.0.1
+                    port: 8888

--- a/charts/otel-collector/values.yaml
+++ b/charts/otel-collector/values.yaml
@@ -5,7 +5,10 @@ collector:
     repository: quay.io/opstree/opentelemetry-collector
     tag: "0.150.1-debian13-contrib"
 
-  containerSecurityContext:
+  securityContext:
+    runAsUser: 65532
+    runAsGroup: 65532
+    runAsNonRoot: true
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
     capabilities:
@@ -98,6 +101,7 @@ collector:
 
     exporters:
       otlp:
+        # Override in client values: point to tempo service in your namespace
         endpoint: tempo:4317
         tls:
           insecure: true
@@ -110,6 +114,7 @@ collector:
         compression: snappy
         timeout: 120s
       prometheusremotewrite:
+        # Override in client values: point to vmsingle service in your namespace
         endpoint: "http://vmsingle-vm.monitoring.svc.cluster.local:8429/api/v1/write"
         max_batch_size_bytes: 3000000
         retry_on_failure:

--- a/charts/otel-collector/values.yaml
+++ b/charts/otel-collector/values.yaml
@@ -162,4 +162,3 @@ collector:
                   prometheus:
                     host: 127.0.0.1
                     port: 8888
-

--- a/charts/otel-collector/values.yaml
+++ b/charts/otel-collector/values.yaml
@@ -162,3 +162,4 @@ collector:
                   prometheus:
                     host: 127.0.0.1
                     port: 8888
+


### PR DESCRIPTION
### Summary
Added OpsTree-managed Otel collector Helm chart wrapping upstream community chart of Otel collector as dependencies with hardened `quay.io/opstree` image, minimal production defaults, zero/minimal vulnerabilities and write permission handling via busybox initContainers.

### Charts Added
| Chart | Upstream Dependency | Version |
|---|---|---|
| `otel-collector` | `open-telemetry/opentelemetry-collector` | 0.123.0 |

### Hardened Images
| Component | Image |
|---|---|
| OTel Collector | `quay.io/opstree/opentelemetry-collector:0.150.1-debian13-contrib` |
