### PR TITLE
Add spring-demo helm chart under charts/new

### DIFF
--- a/charts/new/spring-demo/.helmignore
+++ b/charts/new/spring-demo/.helmignore
@@ -1,0 +1,7 @@
+.git/
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig
+.DS_Store

--- a/charts/new/spring-demo/Chart.yaml
+++ b/charts/new/spring-demo/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: spring-demo
+description: Spring Boot demo app served behind an nginx reverse proxy
+type: application
+version: 0.1.0
+appVersion: "0.0.1-SNAPSHOT"

--- a/charts/new/spring-demo/templates/NOTES.txt
+++ b/charts/new/spring-demo/templates/NOTES.txt
@@ -1,0 +1,21 @@
+spring-demo has been deployed.
+
+{{- if .Values.nginx.enabled }}
+Nginx is exposed via a {{ .Values.nginx.service.type }} Service named {{ include "spring-demo.fullname" . }}-nginx on port {{ .Values.nginx.service.port }}.
+
+{{- if eq .Values.nginx.service.type "ClusterIP" }}
+To access it locally:
+  kubectl port-forward svc/{{ include "spring-demo.fullname" . }}-nginx {{ .Values.nginx.service.port }}:{{ .Values.nginx.service.port }} -n {{ .Release.Namespace }}
+  then open http://localhost:{{ .Values.nginx.service.port }}
+{{- else if eq .Values.nginx.service.type "NodePort" }}
+Get the node port:
+  kubectl get svc {{ include "spring-demo.fullname" . }}-nginx -n {{ .Release.Namespace }} -o jsonpath='{.spec.ports[0].nodePort}'
+{{- else if eq .Values.nginx.service.type "LoadBalancer" }}
+Get the external IP (may take a few minutes to provision):
+  kubectl get svc {{ include "spring-demo.fullname" . }}-nginx -n {{ .Release.Namespace }} -w
+{{- end }}
+{{- else }}
+Nginx is disabled; the app Service {{ include "spring-demo.fullname" . }}-app is only reachable inside the cluster on port {{ .Values.app.service.port }}.
+To access it locally:
+  kubectl port-forward svc/{{ include "spring-demo.fullname" . }}-app {{ .Values.app.service.port }}:{{ .Values.app.service.port }} -n {{ .Release.Namespace }}
+{{- end }}

--- a/charts/new/spring-demo/templates/_helpers.tpl
+++ b/charts/new/spring-demo/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Chart name and version label.
+*/}}
+{{- define "spring-demo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Base fullname used as a prefix for all resource names.
+*/}}
+{{- define "spring-demo.fullname" -}}
+{{- if contains .Chart.Name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "spring-demo.labels" -}}
+helm.sh/chart: {{ include "spring-demo.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels for the app component.
+*/}}
+{{- define "spring-demo.app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spring-demo.fullname" . }}-app
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Selector labels for the nginx component.
+*/}}
+{{- define "spring-demo.nginx.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spring-demo.fullname" . }}-nginx
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/new/spring-demo/templates/app-deployment.yaml
+++ b/charts/new/spring-demo/templates/app-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spring-demo.fullname" . }}-app
+  labels:
+    {{- include "spring-demo.labels" . | nindent 4 }}
+    {{- include "spring-demo.app.selectorLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "spring-demo.app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spring-demo.app.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.app.podSecurityContext | nindent 8 }}
+      containers:
+        - name: app
+          image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}"
+          imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.app.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.app.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.app.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.app.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.app.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.app.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.app.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.app.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.app.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.app.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}

--- a/charts/new/spring-demo/templates/app-service.yaml
+++ b/charts/new/spring-demo/templates/app-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spring-demo.fullname" . }}-app
+  labels:
+    {{- include "spring-demo.labels" . | nindent 4 }}
+    {{- include "spring-demo.app.selectorLabels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.app.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "spring-demo.app.selectorLabels" . | nindent 4 }}

--- a/charts/new/spring-demo/templates/nginx-configmap.yaml
+++ b/charts/new/spring-demo/templates/nginx-configmap.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.nginx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "spring-demo.fullname" . }}-nginx-conf
+  labels:
+    {{- include "spring-demo.labels" . | nindent 4 }}
+    {{- include "spring-demo.nginx.selectorLabels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+
+        gzip on;
+        gzip_types text/plain application/json application/javascript text/css;
+
+        client_max_body_size 1m;
+
+        server {
+
+            listen 80;
+
+            proxy_connect_timeout 5s;
+            proxy_read_timeout 30s;
+            proxy_send_timeout 30s;
+
+            add_header X-Frame-Options "DENY" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Content-Security-Policy "default-src 'self'" always;
+            add_header Permissions-Policy "geolocation=(), camera=(), microphone=()" always;
+
+            location / {
+
+                proxy_pass http://{{ include "spring-demo.fullname" . }}-app:{{ .Values.app.service.port }};
+
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+            }
+
+        }
+
+    }
+{{- end }}

--- a/charts/new/spring-demo/templates/nginx-deployment.yaml
+++ b/charts/new/spring-demo/templates/nginx-deployment.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.nginx.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spring-demo.fullname" . }}-nginx
+  labels:
+    {{- include "spring-demo.labels" . | nindent 4 }}
+    {{- include "spring-demo.nginx.selectorLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.nginx.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "spring-demo.nginx.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spring-demo.nginx.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+        - name: nginx
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.nginx.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+          resources:
+            {{- toYaml .Values.nginx.resources | nindent 12 }}
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: {{ include "spring-demo.fullname" . }}-nginx-conf
+{{- end }}

--- a/charts/new/spring-demo/templates/nginx-service.yaml
+++ b/charts/new/spring-demo/templates/nginx-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.nginx.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spring-demo.fullname" . }}-nginx
+  labels:
+    {{- include "spring-demo.labels" . | nindent 4 }}
+    {{- include "spring-demo.nginx.selectorLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.nginx.service.type }}
+  ports:
+    - port: {{ .Values.nginx.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "spring-demo.nginx.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/new/spring-demo/values.yaml
+++ b/charts/new/spring-demo/values.yaml
@@ -1,0 +1,75 @@
+app:
+  replicaCount: 1
+
+  image:
+    repository: ajitesh70/spring-demo
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  service:
+    port: 8080
+
+  resources:
+    limits:
+      cpu: "1"
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
+
+  probes:
+    liveness:
+      path: /actuator/health/liveness
+      initialDelaySeconds: 40
+      periodSeconds: 15
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readiness:
+      path: /actuator/health/readiness
+      initialDelaySeconds: 20
+      periodSeconds: 15
+      timeoutSeconds: 3
+      failureThreshold: 5
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+nginx:
+  enabled: true
+  replicaCount: 1
+
+  image:
+    repository: nginx
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - NET_BIND_SERVICE
+        - CHOWN
+        - SETUID
+        - SETGID


### PR DESCRIPTION
## Summary
- Adds the spring-demo helm chart (copied from ajitesh00007/gitactions helm/spring-demo) under charts/new/spring-demo

## Test plan
- [ ] helm lint charts/new/spring-demo
- [ ] helm template charts/new/spring-demo